### PR TITLE
skip aud checks

### DIFF
--- a/circuit/src/arrays.rs
+++ b/circuit/src/arrays.rs
@@ -4,7 +4,7 @@
 use crate::TestCircuitHandle;
 use aptos_crypto::poseidon_bn254;
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig,
 };
 use ark_bn254::Fr;
 use ark_ff::{One, Zero};
@@ -24,8 +24,7 @@ fn array_selector_test() {
     for start in 0..out_len {
         for end in start + 1..=out_len {
             let output = build_array_selector_output(out_len, start, end);
-            let config =
-                CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+            let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
             let circuit_input_signals = CircuitInputSignals::new()
                 .u64_input("start_index", start as u64)
                 .u64_input("end_index", end as u64)
@@ -49,7 +48,7 @@ fn array_selector_test_large() {
         let end = rng.gen_range(start + 1, 2001);
 
         let output = build_array_selector_output(out_len, start, end);
-        let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+        let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
         let circuit_input_signals = CircuitInputSignals::new()
             .u64_input("start_index", start as u64)
             .u64_input("end_index", end as u64)
@@ -69,7 +68,7 @@ fn array_selector_test_small() {
     let start = 0;
     let end = 1;
     let output = build_array_selector_output(out_len, start, end);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("start_index", start as u64)
         .u64_input("end_index", end as u64)
@@ -89,7 +88,7 @@ fn array_selector_test_wrong_start() {
     let start = 3;
     let end = 3;
     let output = build_array_selector_output(out_len, start, end);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("start_index", start as u64)
         .u64_input("end_index", end as u64)
@@ -110,8 +109,7 @@ fn array_selector_test_complex() {
     for start in 1..out_len {
         for end in start + 1..=out_len {
             let output = build_array_selector_output(out_len, start, end);
-            let config =
-                CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+            let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
             let circuit_input_signals = CircuitInputSignals::new()
                 .u64_input("start_index", start as u64)
                 .u64_input("end_index", end as u64)
@@ -132,7 +130,7 @@ fn array_selector_test_complex_large() {
     let start = 157;
     let end = 1143;
     let output = build_array_selector_output(out_len, start, end);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("start_index", start as u64)
         .u64_input("end_index", end as u64)
@@ -152,7 +150,7 @@ fn array_selector_test_complex_small() {
     let start = 1;
     let end = 2;
     let output = build_array_selector_output(out_len, start, end);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("start_index", start as u64)
         .u64_input("end_index", end as u64)
@@ -172,7 +170,7 @@ fn array_selector_test_complex_wrong_start() {
     let start = 3;
     let end = 3;
     let output = build_array_selector_output(out_len, start, end);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("start_index", start as u64)
         .u64_input("end_index", end as u64)
@@ -196,7 +194,7 @@ fn left_array_selector_test() {
     let out_len = 8;
     for index in 0..=out_len {
         let output = build_left_array_selector_output(out_len, index);
-        let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+        let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
         let circuit_input_signals = CircuitInputSignals::new()
             .u64_input("index", index as u64)
             .bytes_input("expected_output", &output[..])
@@ -215,7 +213,7 @@ fn left_array_selector_test_large() {
     let mut rng = thread_rng();
     let index = rng.gen_range(0, 2000);
     let output = build_left_array_selector_output(out_len, index);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("expected_output", &output)
@@ -233,7 +231,7 @@ fn left_array_selector_test_small() {
     let out_len = 1;
     let index = 0;
     let output = build_left_array_selector_output(out_len, index);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("expected_output", &output)
@@ -258,7 +256,7 @@ fn right_array_selector_test() {
     let out_len = 8;
     for index in 0..=out_len {
         let output = build_right_array_selector_output(out_len, index);
-        let config = CircuitPaddingConfig::new().max_length("expected_output", out_len);
+        let config = CircuitConfig::new().max_length("expected_output", out_len);
         let circuit_input_signals = CircuitInputSignals::new()
             .u64_input("index", index as u64)
             .bytes_input("expected_output", &output[..])
@@ -277,7 +275,7 @@ fn right_array_selector_test_large() {
     let mut rng = rand::thread_rng();
     let index = rng.gen_range(0, 2001);
     let output = build_right_array_selector_output(out_len, index);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len);
+    let config = CircuitConfig::new().max_length("expected_output", out_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("expected_output", &output)
@@ -295,7 +293,7 @@ fn right_array_selector_test_small() {
     let out_len = 1;
     let index = 0;
     let output = build_left_array_selector_output(out_len, index);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("expected_output", &output)
@@ -321,7 +319,7 @@ fn single_one_array_test() {
     let out_len = 8;
     for index in 0..=out_len {
         let output = build_single_one_array_output(out_len, index);
-        let config = CircuitPaddingConfig::new().max_length("expected_output", out_len);
+        let config = CircuitConfig::new().max_length("expected_output", out_len);
         let circuit_input_signals = CircuitInputSignals::new()
             .u64_input("index", index as u64)
             .bytes_input("expected_output", &output)
@@ -341,7 +339,7 @@ fn single_one_array_large_test() {
     let mut rng = rand::thread_rng();
     let index = rng.gen_range(0, 2001);
     let output = build_single_one_array_output(out_len, index);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len);
+    let config = CircuitConfig::new().max_length("expected_output", out_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("expected_output", &output)
@@ -359,7 +357,7 @@ fn single_one_array_small_test() {
     let out_len = 1;
     let index = 0;
     let output = build_single_one_array_output(out_len, index);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len);
+    let config = CircuitConfig::new().max_length("expected_output", out_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("expected_output", &output)
@@ -379,7 +377,7 @@ fn select_array_value_test() {
     let in_len = array.len();
     for index in 0..in_len {
         let output = array[index];
-        let config = CircuitPaddingConfig::new().max_length("array", in_len);
+        let config = CircuitConfig::new().max_length("array", in_len);
         let circuit_input_signals = CircuitInputSignals::new()
             .u64_input("index", index as u64)
             .bytes_input("array", &array[..])
@@ -402,7 +400,7 @@ fn select_array_value_large_test() {
     let index = 1567;
     let in_len = input.len();
     let output = input[index];
-    let config = CircuitPaddingConfig::new().max_length("array", in_len);
+    let config = CircuitConfig::new().max_length("array", in_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("array", &input)
@@ -423,7 +421,7 @@ fn select_array_value_small_test() {
     let index = 0;
     let in_len = array.len();
     let output = array[index];
-    let config = CircuitPaddingConfig::new().max_length("array", in_len);
+    let config = CircuitConfig::new().max_length("array", in_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("array", &array)
@@ -444,7 +442,7 @@ fn select_array_value_test_wrong_index() {
     let mut rng = rand::thread_rng();
     let output: Vec<u8> = (0..8).map(|_| rng.gen_range(0, 250)).collect();
 
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len as usize);
+    let config = CircuitConfig::new().max_length("expected_output", out_len as usize);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .bytes_input("expected_output", &output)
@@ -469,7 +467,7 @@ fn single_neg_one_array_test() {
     let out_len = 8;
     for index in 0..=out_len {
         let output = build_single_neg_one_array_output(out_len, index);
-        let config = CircuitPaddingConfig::new().max_length("expected_output", out_len);
+        let config = CircuitConfig::new().max_length("expected_output", out_len);
         let circuit_input_signals = CircuitInputSignals::new()
             .u64_input("index", index as u64)
             .frs_input("expected_output", &output)
@@ -489,7 +487,7 @@ fn single_neg_one_array_large_test() {
     let mut rng = rand::thread_rng();
     let index = rng.gen_range(0, 2001);
     let output = build_single_neg_one_array_output(out_len, index);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len);
+    let config = CircuitConfig::new().max_length("expected_output", out_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .frs_input("expected_output", &output)
@@ -507,7 +505,7 @@ fn single_neg_one_array_small_test() {
     let out_len = 1;
     let index = 0;
     let output = build_single_neg_one_array_output(out_len, index);
-    let config = CircuitPaddingConfig::new().max_length("expected_output", out_len);
+    let config = CircuitConfig::new().max_length("expected_output", out_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("index", index as u64)
         .frs_input("expected_output", &output)
@@ -525,7 +523,7 @@ fn check_substr_inclusion_poly_test() {
 
     let max_str_len = 100;
     let max_substr_len = 20;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string = "Hello World!";
@@ -559,7 +557,7 @@ fn check_substr_inclusion_poly_no_padding_test() {
     let string = "Hello World!";
     let max_str_len = string.len();
     let max_substr_len = 11;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string_len = string.len();
@@ -590,7 +588,7 @@ fn check_substr_inclusion_poly_same_test() {
     let string = "Hello World!";
     let max_str_len = 100;
     let max_substr_len = 20;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string_hash = poseidon_bn254::pad_and_hash_string(string, max_str_len).unwrap();
@@ -618,7 +616,7 @@ fn check_substr_inclusion_poly_large_test() {
 
     let max_str_len = 2000;
     let max_substr_len = 1000;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string = "Once upon a midnight dreary, while I pondered, weak and weary,
@@ -651,7 +649,7 @@ fn check_substr_inclusion_poly_small_test() {
 
     let max_str_len = 100;
     let max_substr_len = 20;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string = "a";
@@ -695,7 +693,7 @@ fn check_substr_inclusion_poly_edge_case_test() {
     let substr: &'static [u8] = &[0u8, 0, 0, 0, 0, 0, 5, 192];
     let start_index = 248;
 
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", 256)
         .max_length("substr", 8);
 
@@ -720,7 +718,7 @@ fn check_substr_inclusion_poly_boolean_test() {
 
     let max_str_len = 100;
     let max_substr_len = 20;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string = "Hello World!";
@@ -755,7 +753,7 @@ fn check_substr_inclusion_poly_no_padding_boolean_test() {
     let string = "Hello World!";
     let max_str_len = string.len();
     let max_substr_len = 11;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string_len = string.len();
@@ -787,7 +785,7 @@ fn check_substr_inclusion_poly_same_boolean_test() {
     let string = "Hello World!";
     let max_str_len = 100;
     let max_substr_len = 20;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string_hash = poseidon_bn254::pad_and_hash_string(string, max_str_len).unwrap();
@@ -817,7 +815,7 @@ fn check_substr_inclusion_poly_large_boolean_test() {
 
     let max_str_len = 2000;
     let max_substr_len = 1000;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string = "Once upon a midnight dreary, while I pondered, weak and weary,
@@ -851,7 +849,7 @@ fn check_substr_inclusion_poly_small_boolean_test() {
 
     let max_str_len = 100;
     let max_substr_len = 20;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("str", max_str_len)
         .max_length("substr", max_substr_len);
     let string = "a";
@@ -881,7 +879,7 @@ fn concatenation_check_test() {
     let max_full_str_len = 100;
     let max_left_str_len = 70;
     let max_right_str_len = 70;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("full_string", max_full_str_len)
         .max_length("left", max_left_str_len)
         .max_length("right", max_right_str_len);
@@ -915,7 +913,7 @@ fn concatenation_check_left_len_wrong_test() {
     let max_full_str_len = 100;
     let max_left_str_len = 70;
     let max_right_str_len = 70;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("full_string", max_full_str_len)
         .max_length("left", max_left_str_len)
         .max_length("right", max_right_str_len);
@@ -947,7 +945,7 @@ fn concatenation_check_left_string_wrong_test() {
     let max_full_str_len = 100;
     let max_left_str_len = 70;
     let max_right_str_len = 70;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("full_string", max_full_str_len)
         .max_length("left", max_left_str_len)
         .max_length("right", max_right_str_len);
@@ -979,7 +977,7 @@ fn concatenation_check_right_string_wrong_test() {
     let max_full_str_len = 100;
     let max_left_str_len = 70;
     let max_right_str_len = 70;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("full_string", max_full_str_len)
         .max_length("left", max_left_str_len)
         .max_length("right", max_right_str_len);
@@ -1012,7 +1010,7 @@ fn concatenation_check_small_test() {
     let max_full_str_len = 2;
     let max_left_str_len = 1;
     let max_right_str_len = 1;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("full_string", max_full_str_len)
         .max_length("left", max_left_str_len)
         .max_length("right", max_right_str_len);
@@ -1044,7 +1042,7 @@ fn concatenation_check_large_test() {
     let max_full_str_len = 1600;
     let max_left_str_len = 1000;
     let max_right_str_len = 1000;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("full_string", max_full_str_len)
         .max_length("left", max_left_str_len)
         .max_length("right", max_right_str_len);
@@ -1085,7 +1083,7 @@ fn check_are_ascii_digits_test() {
     input_arr.append(&mut not_digits);
 
     let len = 5;
-    let config = CircuitPaddingConfig::new().max_length("in", max_input_len);
+    let config = CircuitConfig::new().max_length("in", max_input_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("len", len)
         .bytes_input("in", &input_arr)
@@ -1105,7 +1103,7 @@ fn check_are_ascii_digits_max_len_test() {
     let digits: Vec<u8> = (0..8).map(|_| rng.gen_range(0, 9)).collect();
     let input_arr = digits_to_ascii_digits(digits.to_vec());
     let len = input_arr.len();
-    let config = CircuitPaddingConfig::new().max_length("in", max_input_len);
+    let config = CircuitConfig::new().max_length("in", max_input_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("len", len as u64)
         .bytes_input("in", &input_arr)
@@ -1125,7 +1123,7 @@ fn check_are_ascii_digits_small_test() {
     let digits: Vec<u8> = (0..1).map(|_| rng.gen_range(0, 9)).collect();
     let input_arr = digits_to_ascii_digits(digits.to_vec());
     let len = 1;
-    let config = CircuitPaddingConfig::new().max_length("in", max_input_len);
+    let config = CircuitConfig::new().max_length("in", max_input_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("len", len)
         .bytes_input("in", &input_arr)
@@ -1146,7 +1144,7 @@ fn check_are_ascii_digits_large_test() {
     let input_arr = digits_to_ascii_digits(digits.to_vec());
 
     let len = input_arr.len();
-    let config = CircuitPaddingConfig::new().max_length("in", max_input_len);
+    let config = CircuitConfig::new().max_length("in", max_input_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("len", len as u64)
         .bytes_input("in", &input_arr)
@@ -1175,7 +1173,7 @@ fn ascii_digits_to_field_test() {
     let ascii_digits = digits_to_ascii_digits(digits.to_vec());
     let len = 5;
     let expected_output = 21247;
-    let config = CircuitPaddingConfig::new().max_length("digits", max_input_len);
+    let config = CircuitConfig::new().max_length("digits", max_input_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("len", len)
         .bytes_input("digits", &ascii_digits)
@@ -1196,7 +1194,7 @@ fn ascii_digits_to_field_small_test() {
     let ascii_digits = digits_to_ascii_digits(digits.to_vec());
     let len = 1;
     let expected_output = 7;
-    let config = CircuitPaddingConfig::new().max_length("digits", max_input_len);
+    let config = CircuitConfig::new().max_length("digits", max_input_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("len", len)
         .bytes_input("digits", &ascii_digits)
@@ -1224,7 +1222,7 @@ fn ascii_digits_to_field_large_test() {
 
     let len = 19;
     let expected_output = 2124748019218367415;
-    let config = CircuitPaddingConfig::new().max_length("digits", max_input_len);
+    let config = CircuitConfig::new().max_length("digits", max_input_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("len", len)
         .bytes_input("digits", &ascii_digits)
@@ -1246,7 +1244,7 @@ fn ascii_digits_to_field_not_ascii_digits_test() {
     let ascii_digits = digits_to_ascii_digits(digits.to_vec());
     let len = 5;
     let expected_output = 21247;
-    let config = CircuitPaddingConfig::new().max_length("digits", max_input_len);
+    let config = CircuitConfig::new().max_length("digits", max_input_len);
     let circuit_input_signals = CircuitInputSignals::new()
         .u64_input("len", len)
         .bytes_input("digits", &ascii_digits)

--- a/circuit/src/base64.rs
+++ b/circuit/src/base64.rs
@@ -3,7 +3,7 @@
 
 use crate::TestCircuitHandle;
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig,
 };
 use itertools::*;
 
@@ -32,7 +32,7 @@ fn base64_decode_test() {
 
     let max_jwt_payload_len = 192 * 8 - 64;
     let max_ascii_jwt_payload_len = 3 * max_jwt_payload_len / 4;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("jwt_payload", max_jwt_payload_len)
         .max_length("ascii_jwt_payload", max_ascii_jwt_payload_len);
 
@@ -56,7 +56,7 @@ fn base64_lookup_test() {
         .chain([b'-', b'_']);
 
     for in_b64_char in base64_chars {
-        let config = CircuitPaddingConfig::new();
+        let config = CircuitConfig::new();
 
         let circuit_input_signals = CircuitInputSignals::new()
             .byte_input("in_b64_char", in_b64_char)
@@ -79,7 +79,7 @@ fn base64_decode_test_short_all_dashes() {
 
     let max_jwt_payload_len = 4;
     let max_ascii_jwt_payload_len = 3 * max_jwt_payload_len / 4;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("jwt_payload", max_jwt_payload_len)
         .max_length("ascii_jwt_payload", max_ascii_jwt_payload_len);
 
@@ -105,7 +105,7 @@ fn base64_decode_test_short_three_chars() {
 
     let max_jwt_payload_len = 4;
     let max_ascii_jwt_payload_len = 3 * max_jwt_payload_len / 4;
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("jwt_payload", max_jwt_payload_len)
         .max_length("ascii_jwt_payload", max_ascii_jwt_payload_len);
 
@@ -143,7 +143,7 @@ fn base64_decode_test_short_exhaustive() {
 
         let max_jwt_payload_len = 4;
         let max_ascii_jwt_payload_len = 3 * max_jwt_payload_len / 4;
-        let config = CircuitPaddingConfig::new()
+        let config = CircuitConfig::new()
             .max_length("jwt_payload", max_jwt_payload_len)
             .max_length("ascii_jwt_payload", max_ascii_jwt_payload_len);
 

--- a/circuit/src/bigint.rs
+++ b/circuit/src/bigint.rs
@@ -3,7 +3,7 @@
 
 use crate::TestCircuitHandle;
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig,
 };
 use aptos_logger::info;
 use rand::{thread_rng, Rng};
@@ -83,9 +83,7 @@ fn common<F: FnMut() -> (Vec<u8>, Vec<u8>)>(mut a_b_provider: F, expected_output
         let b_bytes_le: Vec<u8> = b_bytes_be.into_iter().rev().collect();
         let b_limbs_le = bytes_le_into_limbs_le(b_bytes_le);
 
-        let config = CircuitPaddingConfig::new()
-            .max_length("a", 32)
-            .max_length("b", 32);
+        let config = CircuitConfig::new().max_length("a", 32).max_length("b", 32);
         let circuit_input_signals = CircuitInputSignals::new()
             .limbs_input("a", a_limbs_le.as_slice())
             .limbs_input("b", b_limbs_le.as_slice())

--- a/circuit/src/hash_to_field.rs
+++ b/circuit/src/hash_to_field.rs
@@ -10,7 +10,7 @@ use aptos_crypto::{
     test_utils::random_bytes,
 };
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig,
 };
 use ark_bn254::Fr;
 use ark_ff::Field;
@@ -63,7 +63,7 @@ component main = hash_bytes_to_field_with_len_test(__MAX_LEN__);
         let expected_output =
             pad_and_hash_bytes_with_len(msg.as_slice(), num_bytes_circuit_capacity).unwrap();
         println!("expected_output={}", expected_output);
-        let config = CircuitPaddingConfig::new().max_length("in", num_bytes_circuit_capacity);
+        let config = CircuitConfig::new().max_length("in", num_bytes_circuit_capacity);
         let circuit_input_signals = CircuitInputSignals::new()
             .bytes_input("in", msg.as_slice())
             .usize_input("len", msg.len())
@@ -120,7 +120,7 @@ component main = HashBytesToFieldTest(__MAX_LEN__);
         let expected_output =
             pad_and_hash_bytes_no_len(msg.as_slice(), num_bytes_circuit_capacity).unwrap();
         println!("expected_output={}", expected_output);
-        let config = CircuitPaddingConfig::new().max_length("in", num_bytes_circuit_capacity);
+        let config = CircuitConfig::new().max_length("in", num_bytes_circuit_capacity);
         let circuit_input_signals = CircuitInputSignals::new()
             .bytes_input("in", msg.as_slice())
             .fr_input("expected_output", expected_output)
@@ -179,7 +179,7 @@ component main = Hash64BitLimbsToFieldWithLenTest(__MAX_LEN__);
         let expected_output =
             pad_and_hash_limbs_with_len(limbs.as_slice(), num_limbs_circuit_capacity).unwrap();
         println!("expected_output={}", expected_output);
-        let config = CircuitPaddingConfig::new().max_length("in", num_limbs_circuit_capacity);
+        let config = CircuitConfig::new().max_length("in", num_limbs_circuit_capacity);
         let circuit_input_signals = CircuitInputSignals::new()
             .limbs_input("in", limbs.as_slice())
             .usize_input("len", limbs.len())
@@ -208,7 +208,7 @@ component main = CheckAre64BitLimbs(__NUM_LIMBS__);
             circuit_src_template.replace("__NUM_LIMBS__", num_limbs.to_string().as_str());
         let circuit = TestCircuitHandle::new_from_str(circuit_src.as_str()).unwrap();
         let limbs: Vec<u64> = (0..num_limbs).map(|_| rng.gen()).collect();
-        let config = CircuitPaddingConfig::new().max_length("in", num_limbs);
+        let config = CircuitConfig::new().max_length("in", num_limbs);
         let circuit_input_signals = CircuitInputSignals::new()
             .limbs_input("in", limbs.as_slice())
             .pad(&config)
@@ -233,7 +233,7 @@ component main = CheckAre64BitLimbs(__NUM_LIMBS__);
         let circuit = TestCircuitHandle::new_from_str(circuit_src.as_str()).unwrap();
         let invalid_limb_value = Fr::from(u64::MAX) + Fr::ONE;
         let frs = vec![invalid_limb_value; num_limbs];
-        let config = CircuitPaddingConfig::new().max_length("in", num_limbs);
+        let config = CircuitConfig::new().max_length("in", num_limbs);
         let circuit_input_signals = CircuitInputSignals::new()
             .frs_input("in", frs.as_slice())
             .pad(&config)

--- a/circuit/src/jwt_field_parsing.rs
+++ b/circuit/src/jwt_field_parsing.rs
@@ -3,7 +3,7 @@
 
 use crate::{misc::calc_string_bodies, TestCircuitHandle};
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig,
 };
 
 struct JWTField<T> {
@@ -140,7 +140,7 @@ fn email_verified_test<T: JWTFieldIndices + JWTFieldStr>(
 ) -> Result<tempfile::NamedTempFile, anyhow::Error> {
     let circuit_handle = TestCircuitHandle::new(test_circom_file).unwrap();
 
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("field", 30)
         .max_length("name", 20)
         .max_length("value", 10);
@@ -168,7 +168,7 @@ fn unquoted_test<T: JWTFieldIndices + JWTFieldStr>(
 ) -> Result<tempfile::NamedTempFile, anyhow::Error> {
     let circuit_handle = TestCircuitHandle::new(test_circom_file).unwrap();
 
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("field", 60)
         .max_length("name", 30)
         .max_length("value", 30);
@@ -196,7 +196,7 @@ fn quoted_test<T: JWTFieldIndices + JWTFieldStr>(
 ) -> Result<tempfile::NamedTempFile, anyhow::Error> {
     let circuit_handle = TestCircuitHandle::new(test_circom_file).unwrap();
 
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("field", 60)
         .max_length("field_string_bodies", 60)
         .max_length("name", 30)

--- a/circuit/src/misc.rs
+++ b/circuit/src/misc.rs
@@ -3,7 +3,7 @@
 
 use crate::TestCircuitHandle;
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig,
 };
 use ark_bn254::Fr;
 use ark_ff::PrimeField;
@@ -91,7 +91,7 @@ fn is_whitespace_test() {
     let circuit_handle = TestCircuitHandle::new("misc/is_whitespace_test.circom").unwrap();
 
     for c in 0u8..=127u8 {
-        let config = CircuitPaddingConfig::new();
+        let config = CircuitConfig::new();
 
         let circuit_input_signals = CircuitInputSignals::new()
             .byte_input("char", c)
@@ -115,7 +115,7 @@ fn string_bodies_test() {
 
     assert_eq!(quotes_b, calc_string_bodies(s));
 
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("in", 13)
         .max_length("out", 13);
 
@@ -140,7 +140,7 @@ fn string_bodies_test_2() {
 
     assert_eq!(quotes_b, calc_string_bodies(s));
 
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("in", 13)
         .max_length("out", 13);
 
@@ -163,7 +163,7 @@ fn string_bodies_test_random() {
         let s = generate_string_bodies_input();
         let quotes = calc_string_bodies(&s);
 
-        let config = CircuitPaddingConfig::new()
+        let config = CircuitConfig::new()
             .max_length("in", 13)
             .max_length("out", 13);
 
@@ -192,7 +192,7 @@ fn string_bodies_test_prefix_quotes() {
 
         let quotes = calc_string_bodies(&s);
 
-        let config = CircuitPaddingConfig::new()
+        let config = CircuitConfig::new()
             .max_length("in", 13)
             .max_length("out", 13);
 
@@ -215,7 +215,7 @@ fn string_bodies_test_zjma() {
     let s = "\"abc\\\\\"";
     let quotes = calc_string_bodies(s);
 
-    let config = CircuitPaddingConfig::new()
+    let config = CircuitConfig::new()
         .max_length("in", 13)
         .max_length("out", 13);
 
@@ -241,7 +241,7 @@ fn calculate_total_test() {
 
         let sum: Fr = nums.iter().sum();
 
-        let config = CircuitPaddingConfig::new().max_length("nums", 10);
+        let config = CircuitConfig::new().max_length("nums", 10);
 
         let circuit_input_signals = CircuitInputSignals::new()
             .frs_input("nums", &nums)
@@ -284,7 +284,7 @@ fn assert_equal_if_true_test() {
             (nums, true)
         };
 
-        let config = CircuitPaddingConfig::new().max_length("in", 2);
+        let config = CircuitConfig::new().max_length("in", 2);
 
         let circuit_input_signals = CircuitInputSignals::new()
             .frs_input("in", &nums)
@@ -324,7 +324,7 @@ fn email_verified_check_test() {
         let expected_uid_is_email = t.3;
         let test_should_pass = t.4;
 
-        let config = CircuitPaddingConfig::new()
+        let config = CircuitConfig::new()
             .max_length("ev_name", 20)
             .max_length("ev_value", 10)
             .max_length("uid_name", 30);

--- a/circuit/src/packing.rs
+++ b/circuit/src/packing.rs
@@ -3,7 +3,7 @@
 
 use crate::TestCircuitHandle;
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig,
 };
 use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField};
@@ -39,7 +39,7 @@ fn num2bits_be_test() {
     let bits_max_size = 8;
 
     for n in 0..=255 {
-        let config = CircuitPaddingConfig::new().max_length("bits_out", bits_max_size);
+        let config = CircuitConfig::new().max_length("bits_out", bits_max_size);
 
         let circuit_input_signals = CircuitInputSignals::new()
             .byte_input("num_in", n)
@@ -62,7 +62,7 @@ fn bits2num_big_endian_test() {
     for i in 0..=255 {
         let expected_n = rng.next_u64();
 
-        let config = CircuitPaddingConfig::new().max_length("bits_in", bits_max_size);
+        let config = CircuitConfig::new().max_length("bits_in", bits_max_size);
 
         let circuit_input_signals = CircuitInputSignals::new()
             .bools_input("bits_in", &expected_num2bits_be(expected_n, bits_max_size))
@@ -93,7 +93,7 @@ fn bytes_to_bits_test() {
             .flat_map(|byte| expected_num2bits_be(*byte as u64, 8))
             .collect();
 
-        let config = CircuitPaddingConfig::new()
+        let config = CircuitConfig::new()
             .max_length("bytes_in", BYTES_MAX_SIZE)
             .max_length("bits_out", BITS_MAX_SIZE);
 
@@ -133,7 +133,7 @@ fn bits_to_field_elems_test() {
         let expected_field_elems = bits_to_field_elems(&bits, BITS_PER_FIELD_ELEM);
         println!("{}", expected_field_elems.len());
 
-        let config = CircuitPaddingConfig::new()
+        let config = CircuitConfig::new()
             .max_length("bits_in", MAX_BITS_LEN)
             .max_length("field_elems_out", num_field_elems);
 

--- a/circuit/src/rsa.rs
+++ b/circuit/src/rsa.rs
@@ -3,7 +3,7 @@
 
 use crate::TestCircuitHandle;
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig,
 };
 use aptos_logger::info;
 use num_bigint::BigUint;
@@ -108,7 +108,7 @@ fn common<F: Fn(&mut Vec<u64>, &mut Vec<u64>, &mut Vec<u64>)>(
         );
         let mut signature_limbs = signature.to_u64_digits();
 
-        let config = CircuitPaddingConfig::new();
+        let config = CircuitConfig::new();
 
         update_signals(
             &mut signature_limbs,

--- a/circuit/src/sha.rs
+++ b/circuit/src/sha.rs
@@ -3,7 +3,7 @@
 
 use crate::TestCircuitHandle;
 use aptos_keyless_common::input_processing::{
-    circuit_input_signals::CircuitInputSignals, config::CircuitPaddingConfig, sha,
+    circuit_input_signals::CircuitInputSignals, config::CircuitConfig, sha,
 };
 use rand_chacha::{
     rand_core::{RngCore as _, SeedableRng as _},
@@ -40,7 +40,7 @@ fn sha_test() {
         let expected_output = hasher.finalize().to_vec();
         let expected_output_bits = bytes_to_bits_msb(expected_output);
 
-        let config = CircuitPaddingConfig::new()
+        let config = CircuitConfig::new()
             .max_length("padded_input_bits", 2048) // should align with the `max_num_blocks=4` in `sha_test.circom`.
             .max_length("expected_digest_bits", 256);
 
@@ -68,7 +68,7 @@ fn sha_padding_verify_test() {
         rng.fill_bytes(&mut input);
         let padded_input = sha::with_sha_padding_bytes(&input);
         let padded_input_byte_len = padded_input.len();
-        let config = CircuitPaddingConfig::new()
+        let config = CircuitConfig::new()
             .max_length("in", 256)
             .max_length("L_byte_encoded", 8)
             .max_length("padding_without_len", 64);

--- a/keyless-common/src/input_processing/circuit_input_signals.rs
+++ b/keyless-common/src/input_processing/circuit_input_signals.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::config::CircuitPaddingConfig;
+use super::config::CircuitConfig;
 use anyhow::{anyhow, bail, Result};
 use ark_bn254::Fr;
 use serde_json::Value;
@@ -141,7 +141,7 @@ impl CircuitInputSignals<Unpadded> {
         })
     }
 
-    pub fn pad(self, config: &CircuitPaddingConfig) -> Result<CircuitInputSignals<Padded>> {
+    pub fn pad(self, config: &CircuitConfig) -> Result<CircuitInputSignals<Padded>> {
         let padded_signals_vec: Result<Vec<(String, CircuitInputSignal)>> = self
             .signals
             .into_iter()

--- a/keyless-common/src/input_processing/config.rs
+++ b/keyless-common/src/input_processing/config.rs
@@ -5,15 +5,18 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct CircuitPaddingConfig {
+pub struct CircuitConfig {
     pub max_lengths: BTreeMap<String, usize>,
+    #[serde(default)]
+    pub has_input_skip_aud_checks: bool,
 }
 
-impl CircuitPaddingConfig {
+impl CircuitConfig {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             max_lengths: BTreeMap::new(),
+            has_input_skip_aud_checks: false,
         }
     }
 

--- a/prover/Dockerfile
+++ b/prover/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p /resources/setup_2024_05 \
     && curl --location -o /resources/setup_2024_05/main_c https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_c_cpp/main_c \
     && curl --location -o /resources/setup_2024_05/main_c.dat https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_c_cpp/main_c.dat \
     && curl --location -o /resources/setup_2024_05/verification_key.json https://github.com/aptos-labs/aptos-keyless-trusted-setup-contributions-may-2024/raw/main/verification_key_39f9c44b4342ed5e6941fae36cf6c87c52b1e17f.vkey \
-    && curl --location -o /resources/setup_2024_05/circuit_config.yml https://github.com/aptos-labs/devnet-groth16-keys/raw/master/circuit_config.yml \
+    && curl --location -o /resources/setup_2024_05/circuit_config.yml https://raw.githubusercontent.com/aptos-labs/aptos-keyless-trusted-setup-contributions-may-2024/0f2ca4730147c5d4123b9c32a0cf0bd800f36b38/circuit_config.yml \
     #    && mkdir -p /resources/setup_2024_02 \
 #    && curl --location -o /resources/setup_2024_02/prover_key.zkey https://github.com/aptos-labs/aptos-keyless-trusted-setup-contributions-may-2024/raw/main/contributions/main_39f9c44b4342ed5e6941fae36cf6c87c52b1e17f_final.zkey \
 #    && curl --location -o /resources/setup_2024_02/main_c https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_c_cpp/main_c \

--- a/prover/Dockerfile
+++ b/prover/Dockerfile
@@ -31,11 +31,13 @@ RUN mkdir -p /resources/setup_2024_05 \
     && curl --location -o /resources/setup_2024_05/main_c https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_c_cpp/main_c \
     && curl --location -o /resources/setup_2024_05/main_c.dat https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_c_cpp/main_c.dat \
     && curl --location -o /resources/setup_2024_05/verification_key.json https://github.com/aptos-labs/aptos-keyless-trusted-setup-contributions-may-2024/raw/main/verification_key_39f9c44b4342ed5e6941fae36cf6c87c52b1e17f.vkey \
-#    && mkdir -p /resources/setup_2024_02 \
+    && curl --location -o /resources/setup_2024_05/circuit_config.yml https://github.com/aptos-labs/devnet-groth16-keys/raw/master/circuit_config.yml \
+    #    && mkdir -p /resources/setup_2024_02 \
 #    && curl --location -o /resources/setup_2024_02/prover_key.zkey https://github.com/aptos-labs/aptos-keyless-trusted-setup-contributions-may-2024/raw/main/contributions/main_39f9c44b4342ed5e6941fae36cf6c87c52b1e17f_final.zkey \
 #    && curl --location -o /resources/setup_2024_02/main_c https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_c_cpp/main_c \
 #    && curl --location -o /resources/setup_2024_02/main_c.dat https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_c_cpp/main_c.dat \
 #    && curl --location -o /resources/setup_2024_02/verification_key.json https://github.com/aptos-labs/aptos-keyless-trusted-setup-contributions-may-2024/raw/main/verification_key_39f9c44b4342ed5e6941fae36cf6c87c52b1e17f.vkey \
+#    && curl --location -o /resources/setup_2024_02/circuit_config.yml https://github.com/aptos-labs/devnet-groth16-keys/raw/master/circuit_config.yml \
     && echo "Resources ready."
 
 RUN chmod u+x /resources/setup_2024_05/main_c
@@ -43,7 +45,6 @@ RUN chmod u+x /resources/setup_2024_05/main_c
 
 
 COPY --link ./prover/config.yml ./config.yml
-COPY --link ./prover/conversion_config.yml ./conversion_config.yml
 
 EXPOSE 8080
 

--- a/prover/scripts/dev_setup.sh
+++ b/prover/scripts/dev_setup.sh
@@ -84,6 +84,9 @@ curl --location -o "$RESOURCES_DIR/setup_2024_05/generate_witness.js" https://gi
 curl --location -o "$RESOURCES_DIR/setup_2024_05/main.wasm" https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_js/main.wasm
 curl --location -o "$RESOURCES_DIR/setup_2024_05/witness_calculator.js" https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_js/witness_calculator.js
 
+# Get extra circuit config
+curl --location -o "$RESOURCES_DIR/setup_2024_05/circuit_config.yml" https://github.com/aptos-labs/devnet-groth16-keys/raw/master/circuit_config.yml
+
 # TODO: replace with the next realworld setup data once it is available.
 #  Currently using the initial setup data as a placeholder. NOTE: it does not work with the current prove request scheme.
 #mkdir -p $RESOURCES_DIR/setup_2024_02
@@ -94,6 +97,7 @@ curl --location -o "$RESOURCES_DIR/setup_2024_05/witness_calculator.js" https://
 #curl --location -o "$RESOURCES_DIR/setup_2024_02/generate_witness.js" https://raw.githubusercontent.com/aptos-labs/devnet-groth16-keys/42deb24b17f6f0370a6fcf6db9e0696a5bdf767a/main_js/generate_witness.js
 #curl --location -o "$RESOURCES_DIR/setup_2024_02/main.wasm" https://github.com/aptos-labs/devnet-groth16-keys/raw/42deb24b17f6f0370a6fcf6db9e0696a5bdf767a/main_js/main.wasm
 #curl --location -o "$RESOURCES_DIR/setup_2024_02/witness_calculator.js" https://github.com/aptos-labs/devnet-groth16-keys/raw/42deb24b17f6f0370a6fcf6db9e0696a5bdf767a/main_js/witness_calculator.js
+#curl --location -o "$RESOURCES_DIR/setup_2024_02/circuit_config.yml" https://github.com/aptos-labs/devnet-groth16-keys/raw/42deb24b17f6f0370a6fcf6db9e0696a5bdf767a/circuit_config.yml
 
 chmod -R u+rwx $RESOURCES_DIR
 

--- a/prover/scripts/dev_setup.sh
+++ b/prover/scripts/dev_setup.sh
@@ -85,7 +85,7 @@ curl --location -o "$RESOURCES_DIR/setup_2024_05/main.wasm" https://github.com/a
 curl --location -o "$RESOURCES_DIR/setup_2024_05/witness_calculator.js" https://github.com/aptos-labs/devnet-groth16-keys/raw/master/main_js/witness_calculator.js
 
 # Get extra circuit config
-curl --location -o "$RESOURCES_DIR/setup_2024_05/circuit_config.yml" https://github.com/aptos-labs/devnet-groth16-keys/raw/master/circuit_config.yml
+curl --location -o "$RESOURCES_DIR/setup_2024_05/circuit_config.yml" https://raw.githubusercontent.com/aptos-labs/aptos-keyless-trusted-setup-contributions-may-2024/0f2ca4730147c5d4123b9c32a0cf0bd800f36b38/circuit_config.yml
 
 # TODO: replace with the next realworld setup data once it is available.
 #  Currently using the initial setup data as a placeholder. NOTE: it does not work with the current prove request scheme.

--- a/prover/src/api.rs
+++ b/prover/src/api.rs
@@ -26,6 +26,8 @@ pub struct RequestInput {
     pub idc_aud: Option<String>,
     #[serde(default)]
     pub use_insecure_test_jwk: bool,
+    #[serde(default)]
+    pub skip_aud_checks: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -1,5 +1,6 @@
 // Copyright © Aptos Foundation
 
+use aptos_keyless_common::input_processing::config::CircuitConfig;
 use serde::{Deserialize, Serialize};
 
 pub const CONFIG_FILE_PATH: &str = "config.yml";
@@ -94,6 +95,24 @@ impl ProverServiceConfig {
                 + "/main.wasm"),
         )
         .into_owned()
+    }
+
+    pub fn circuit_config_path(&self, use_new_setup: bool) -> String {
+        shellexpand::tilde(
+            &(String::from(&self.resources_dir)
+                + "/"
+                + self.setup_dir(use_new_setup)
+                + "/circuit_config.yml"),
+        )
+        .into_owned()
+    }
+
+    pub fn load_circuit_config(&self, use_new_setup: bool) -> CircuitConfig {
+        println!("load_circuit_config, use_new_setup={use_new_setup}");
+        let path = self.circuit_config_path(use_new_setup);
+        println!("load_circuit_config, path={path}");
+        let circuit_config_yaml = std::fs::read_to_string(path).unwrap();
+        serde_yaml::from_str(&circuit_config_yaml).unwrap()
     }
 }
 

--- a/prover/src/input_processing/field_check_input.rs
+++ b/prover/src/input_processing/field_check_input.rs
@@ -122,7 +122,9 @@ pub fn signals_for_field_with_key(
 //
 
 pub fn private_aud_value(input: &Input) -> Result<String> {
-    if let Some(v) = &input.idc_aud {
+    if input.skip_aud_checks {
+        Ok("".to_string())
+    } else if let Some(v) = &input.idc_aud {
         Ok(v.clone())
     } else {
         let parsed_field =

--- a/prover/src/input_processing/preprocess.rs
+++ b/prover/src/input_processing/preprocess.rs
@@ -40,5 +40,6 @@ pub fn decode_and_add_jwk(
         extra_field: rqi.extra_field,
         exp_horizon_secs: rqi.exp_horizon_secs,
         idc_aud: rqi.idc_aud,
+        skip_aud_checks: rqi.skip_aud_checks,
     })
 }

--- a/prover/src/input_processing/public_inputs_hash.rs
+++ b/prover/src/input_processing/public_inputs_hash.rs
@@ -4,13 +4,13 @@ use super::{field_check_input, field_parser::FieldParser};
 use crate::input_processing::types::Input;
 use anyhow::{anyhow, Result};
 use aptos_crypto::poseidon_bn254;
-use aptos_keyless_common::input_processing::config::CircuitPaddingConfig;
+use aptos_keyless_common::input_processing::config::CircuitConfig;
 use aptos_types::keyless::{Configuration, IdCommitment};
 use ark_bn254::Fr;
 
 pub fn compute_idc_hash(
     input: &Input,
-    config: &CircuitPaddingConfig,
+    config: &CircuitConfig,
     pepper_fr: Fr,
     jwt_payload: &str,
 ) -> Result<Fr> {
@@ -63,10 +63,7 @@ pub fn compute_temp_pubkey_frs(input: &Input) -> Result<([Fr; 3], Fr)> {
     ))
 }
 
-pub fn compute_public_inputs_hash(
-    input: &Input,
-    config: &CircuitPaddingConfig,
-) -> anyhow::Result<Fr> {
+pub fn compute_public_inputs_hash(input: &Input, config: &CircuitConfig) -> anyhow::Result<Fr> {
     let pepper_fr = input.pepper_fr;
     let jwt_parts = &input.jwt_parts;
     let jwk = &input.jwk;
@@ -174,7 +171,7 @@ mod tests {
         poseidon_bn254,
     };
     use aptos_keyless_common::input_processing::{
-        config::CircuitPaddingConfig,
+        config::CircuitConfig,
         encoding::{FromB64, JwtParts},
         sha::with_sha_padding_bytes,
     };
@@ -215,6 +212,7 @@ mod tests {
             uid_key: String::from("sub"),
             extra_field: Some(String::from("family_name")),
             idc_aud: None,
+            skip_aud_checks: false,
         };
 
         let jwt_parts = &input.jwt_parts;
@@ -231,7 +229,7 @@ mod tests {
         )
         .unwrap();
 
-        let config: CircuitPaddingConfig = serde_yaml::from_str(
+        let config: CircuitConfig = serde_yaml::from_str(
             &fs::read_to_string("conversion_config.yml").expect("Unable to read file"),
         )
         .expect("should parse correctly");

--- a/prover/src/input_processing/types.rs
+++ b/prover/src/input_processing/types.rs
@@ -18,6 +18,7 @@ pub struct Input {
     pub extra_field: Option<String>,
     pub exp_horizon_secs: u64,
     pub idc_aud: Option<String>,
+    pub skip_aud_checks: bool,
 }
 
 impl Input {

--- a/prover/src/tests/common/mod.rs
+++ b/prover/src/tests/common/mod.rs
@@ -16,7 +16,7 @@ use aptos_crypto::{
     encoding_type::EncodingType,
     Uniform,
 };
-use aptos_keyless_common::input_processing::{config::CircuitPaddingConfig, encoding::AsFr};
+use aptos_keyless_common::input_processing::{config::CircuitConfig, encoding::AsFr};
 use aptos_types::{
     jwks::rsa::RSA_JWK, keyless::Pepper, transaction::authenticator::EphemeralPublicKey,
 };
@@ -51,7 +51,7 @@ pub fn init_test_full_prover(use_new_setup: bool) -> FullProver {
         .expect("failed to initialize rapidsnark prover")
 }
 
-pub fn get_test_circuit_config() -> CircuitPaddingConfig {
+pub fn get_test_circuit_config() -> CircuitConfig {
     serde_yaml::from_str(&fs::read_to_string("conversion_config.yml").expect("Unable to read file"))
         .expect("should parse correctly")
 }
@@ -113,6 +113,7 @@ pub async fn convert_prove_and_verify(
     let full_prover = init_test_full_prover(false);
     let full_prover_2 = init_test_full_prover(true);
     let circuit_config = get_test_circuit_config();
+    let circuit_config_new = get_test_circuit_config();
     let jwk_keypair = gen_test_jwk_keypair();
     let (tw_sk_default, _) = gen_test_training_wheels_keypair();
     let (tw_sk_new, tw_pk_new) = gen_test_training_wheels_keypair();
@@ -147,6 +148,7 @@ pub async fn convert_prove_and_verify(
         tw_keypair_new,
         config: prover_server_config.clone(),
         circuit_config: circuit_config.clone(),
+        circuit_config_new: Some(circuit_config_new.clone()),
     };
 
     let prover_request_input = testcase.convert_to_prover_request(&jwk_keypair);

--- a/prover/src/tests/common/types.rs
+++ b/prover/src/tests/common/types.rs
@@ -8,7 +8,7 @@ use crate::{
     input_processing::rsa::RsaPrivateKey,
     training_wheels::verification_logic::compute_nonce,
 };
-use aptos_keyless_common::input_processing::{config::CircuitPaddingConfig, encoding::FromFr};
+use aptos_keyless_common::input_processing::{config::CircuitConfig, encoding::FromFr};
 use aptos_types::{
     jwks::rsa::RSA_JWK, keyless::Pepper, transaction::authenticator::EphemeralPublicKey,
 };
@@ -151,6 +151,7 @@ pub struct ProofTestCase<T: Serialize + WithNonce + Clone> {
     pub extra_field: Option<String>,
     pub uid_key: String,
     pub idc_aud: Option<String>,
+    pub skip_aud_checks: bool,
 }
 
 impl<T: Serialize + WithNonce + Clone> ProofTestCase<T> {
@@ -164,7 +165,7 @@ impl<T: Serialize + WithNonce + Clone> ProofTestCase<T> {
         extra_field: Option<String>,
         uid_key: String,
         idc_aud: Option<String>,
-        config: &CircuitPaddingConfig,
+        config: &CircuitConfig,
     ) -> Self {
         let epk = gen_test_ephemeral_pk();
         let epk_blinder = gen_test_ephemeral_pk_blinder();
@@ -182,6 +183,7 @@ impl<T: Serialize + WithNonce + Clone> ProofTestCase<T> {
             extra_field,
             uid_key,
             idc_aud: idc_aud,
+            skip_aud_checks: false,
         }
     }
 
@@ -200,10 +202,11 @@ impl<T: Serialize + WithNonce + Clone> ProofTestCase<T> {
             extra_field: Some(String::from("name")),
             uid_key: String::from("email"),
             idc_aud: None,
+            skip_aud_checks: false,
         }
     }
 
-    pub fn compute_nonce(self, config: &CircuitPaddingConfig) -> Self {
+    pub fn compute_nonce(self, config: &CircuitConfig) -> Self {
         let nonce = compute_nonce(
             self.epk_expiry_time_secs,
             &self.epk,
@@ -233,6 +236,7 @@ impl<T: Serialize + WithNonce + Clone> ProofTestCase<T> {
             extra_field: self.extra_field.clone(),
             idc_aud: self.idc_aud.clone(),
             use_insecure_test_jwk: false,
+            skip_aud_checks: self.skip_aud_checks,
         }
     }
 }

--- a/prover/src/training_wheels/verification_logic.rs
+++ b/prover/src/training_wheels/verification_logic.rs
@@ -5,7 +5,7 @@ use std::{
 
 use aptos_crypto::poseidon_bn254;
 use aptos_keyless_common::input_processing::{
-    config::CircuitPaddingConfig,
+    config::CircuitConfig,
     encoding::{FromB64, JwtHeader, JwtParts, JwtPayload},
 };
 use aptos_types::{
@@ -23,7 +23,7 @@ use crate::{
 };
 use anyhow::{bail, Context, Result};
 
-pub fn check_nonce_consistency(input: &Input, circuit_config: &CircuitPaddingConfig) -> Result<()> {
+pub fn check_nonce_consistency(input: &Input, circuit_config: &CircuitConfig) -> Result<()> {
     let payload_decoded = input.jwt_parts.payload_decoded()?;
     let payload_struct: JwtPayload = serde_json::from_str(&payload_decoded)?;
     let computed_nonce = compute_nonce(
@@ -118,7 +118,7 @@ pub fn compute_nonce(
     exp_date: u64,
     epk: &EphemeralPublicKey,
     epk_blinder: Fr,
-    config: &CircuitPaddingConfig,
+    config: &CircuitConfig,
 ) -> Result<Fr> {
     let mut frs = poseidon_bn254::keyless::pad_and_pack_bytes_to_scalars_with_len(
         epk.to_bytes().as_slice(),


### PR DESCRIPTION
## Context

The new VK rotation flow proposed.

1. Make the current change to the prover.
1. Do the ceremony and get new_pk, new_vk.
1. Install new_pk to the prover.
1. Install new_vk to the chain.
1. Update SDK to start specifying `skip_aud_checks`.

## Changes 

`RequestInput` will have a new optional boolean field `skip_aud_checks`, defaulting to FALSE.

`CircuitPaddingConfig` is refactored to `CircuitConfig` and is now per-circuit. (Currently, it is used for both old circuit and new circuit.)

`CircuitConfig` has a new boolean field `has_input_skip_aud_checks` which, if set, ensure an input signal (name: `skip_aud_checks`, value: coming from field `skip_aud_checks` of the `RequestInput` currently being processed).

NOTE: circuit selection is still orthogonal.