### PR TITLE
Add two observability endpoints for the `Configuration` and the `Groth16VerificationKey`

### DIFF
--- a/prover/src/main.rs
+++ b/prover/src/main.rs
@@ -17,7 +17,7 @@ use axum_prometheus::{
     PrometheusMetricLayerBuilder, AXUM_HTTP_REQUESTS_DURATION_SECONDS,
 };
 use prover_service::groth16_vk::ON_CHAIN_GROTH16_VK;
-use prover_service::prover_key::ON_CHAIN_TW_PK;
+use prover_service::prover_key::ON_CHAIN_KEYLESS_CONFIG;
 use prover_service::watcher::start_external_resource_refresh_loop;
 use std::{fs, net::SocketAddr, sync::Arc, time::Duration};
 use tower::ServiceBuilder;
@@ -69,7 +69,7 @@ async fn main() {
             start_external_resource_refresh_loop(
                 url.as_str(),
                 Duration::from_secs(10),
-                ON_CHAIN_TW_PK.clone(),
+                ON_CHAIN_KEYLESS_CONFIG.clone(),
             );
         }
         Err(_e) => {
@@ -104,6 +104,14 @@ async fn main() {
         .route(
             "/v0/prove",
             post(handlers::prove_handler).fallback(handlers::fallback_handler),
+        )
+        .route(
+            "cached/groth16-vk",
+            get(handlers::cached_groth16_vk_handler),
+        )
+        .route(
+            "cached/keyless-config",
+            get(handlers::cached_keyless_config),
         )
         .route("/healthcheck", get(handlers::healthcheck_handler))
         .fallback(handlers::fallback_handler)

--- a/prover/src/prover_key.rs
+++ b/prover/src/prover_key.rs
@@ -93,7 +93,7 @@ impl TrainingWheelsKeyPair {
     }
 }
 
-pub static ON_CHAIN_TW_PK: Lazy<Arc<RwLock<Option<OnChainKeylessConfiguration>>>> =
+pub static ON_CHAIN_KEYLESS_CONFIG: Lazy<Arc<RwLock<Option<OnChainKeylessConfiguration>>>> =
     Lazy::new(|| Arc::new(RwLock::new(None)));
 
 /// This is not a UT, but a tool to convert a .vkey to its on-chain representation and save in a file.

--- a/prover/src/tests/common/mod.rs
+++ b/prover/src/tests/common/mod.rs
@@ -36,7 +36,9 @@ use tokio::sync::Mutex;
 pub mod types;
 
 use crate::groth16_vk::ON_CHAIN_GROTH16_VK;
-use crate::prover_key::{OnChainKeylessConfiguration, TrainingWheelsKeyPair, ON_CHAIN_TW_PK};
+use crate::prover_key::{
+    OnChainKeylessConfiguration, TrainingWheelsKeyPair, ON_CHAIN_KEYLESS_CONFIG,
+};
 use crate::state::SetupSpecificState;
 
 const TEST_JWK_EXPONENT_STR: &str = "65537";
@@ -127,9 +129,9 @@ pub async fn convert_prove_and_verify(
 
     // Fill external resource caches.
     ON_CHAIN_GROTH16_VK.write().unwrap().clone_from(&new_vk);
-    *ON_CHAIN_TW_PK.write().unwrap() = Some(OnChainKeylessConfiguration::from_tw_pk(Some(
-        tw_pk_new.clone(),
-    )));
+    *ON_CHAIN_KEYLESS_CONFIG.write().unwrap() = Some(OnChainKeylessConfiguration::from_tw_pk(
+        Some(tw_pk_new.clone()),
+    ));
 
     DECODING_KEY_CACHE.insert(String::from("test.oidc.provider"), dm);
 


### PR DESCRIPTION
Adding 2 observation endpoints.
- `/cached/keyless-config` returns the latest keyless config found on chain.
- `/cached/groth16-vk` returns the latest groth16 vk found on chain.
