### PR TITLE
`/meta` endpoint for better observability

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -54,3 +54,5 @@ jobs:
           tags: |
             us-docker.pkg.dev/aptos-registry/docker/prover-service:latest
             us-docker.pkg.dev/aptos-registry/docker/prover-service:${{ github.sha }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}

--- a/prover/Dockerfile
+++ b/prover/Dockerfile
@@ -22,9 +22,8 @@ RUN apt-get update \
 COPY --link --from=build_prover_service ./prover-service-bin ./prover-service-bin
 COPY --link --from=build_prover_service ./prover/rust-rapidsnark/rapidsnark/package ./rapidsnark-package
 
-
-ARG TRUSTLESS_REPO_GIT_SHA=ae684b376059c791ded97d89c3ca114edc1cb44c
-ARG GROTH16_KEYS_REPO_GIT_SHA=6625c811aed782067875cf7998c143f8db17324e
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
 
 COPY scripts scripts
 ENV RESOURCES_DIR=/resources

--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -2,11 +2,11 @@
 
 use crate::groth16_vk::{OnChainGroth16VerificationKey, SnarkJsGroth16VerificationKey};
 use aptos_keyless_common::input_processing::config::CircuitConfig;
+use figment::providers::{Env, Format, Yaml};
+use figment::Figment;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use figment::Figment;
-use figment::providers::{Env, Format, Yaml};
-use once_cell::sync::Lazy;
 
 pub const CONFIG_FILE_PATH: &str = "config.yml";
 pub const LOCAL_TESTING_CONFIG_FILE_PATH: &str = "config_local_testing.yml";
@@ -41,9 +41,9 @@ pub struct ProverServiceConfig {
     pub use_insecure_jwk_for_test: bool,
 }
 
-pub static CONFIG: Lazy<ProverServiceConfig> = Lazy::new(||{
-    let config_file_path = std::env::var(CONFIG_FILE_PATH_ENVVAR)
-        .unwrap_or(String::from(CONFIG_FILE_PATH));
+pub static CONFIG: Lazy<ProverServiceConfig> = Lazy::new(|| {
+    let config_file_path =
+        std::env::var(CONFIG_FILE_PATH_ENVVAR).unwrap_or(String::from(CONFIG_FILE_PATH));
     Figment::new()
         .merge(Yaml::file(config_file_path))
         .merge(Env::raw())

--- a/prover/src/main.rs
+++ b/prover/src/main.rs
@@ -1,6 +1,10 @@
 // Copyright © Aptos Foundation
 
-use axum::{http::header, routing::{get, post}, Router, Json};
+use axum::{
+    http::header,
+    routing::{get, post},
+    Json, Router,
+};
 use http::{Method, StatusCode};
 use log::info;
 use prometheus::{Encoder, TextEncoder};
@@ -12,6 +16,7 @@ use axum_prometheus::{
     utils::SECONDS_DURATION_BUCKETS,
     PrometheusMetricLayerBuilder, AXUM_HTTP_REQUESTS_DURATION_SECONDS,
 };
+use prover_service::config::CONFIG;
 use prover_service::groth16_vk::ON_CHAIN_GROTH16_VK;
 use prover_service::prover_key::ON_CHAIN_KEYLESS_CONFIG;
 use prover_service::watcher::start_external_resource_refresh_loop;
@@ -19,7 +24,6 @@ use std::{fs, net::SocketAddr, sync::Arc, time::Duration};
 use tower::ServiceBuilder;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::warn;
-use prover_service::config::CONFIG;
 
 #[tokio::main]
 async fn main() {
@@ -97,10 +101,7 @@ async fn main() {
 
     // init axum and serve public routes
     let app = Router::new()
-        .route(
-            "/meta",
-                get((StatusCode::OK, Json(CONFIG.clone()))),
-        )
+        .route("/meta", get((StatusCode::OK, Json(CONFIG.clone()))))
         .route(
             "/v0/prove",
             post(handlers::prove_handler).fallback(handlers::fallback_handler),

--- a/prover/src/state.rs
+++ b/prover/src/state.rs
@@ -1,18 +1,13 @@
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_keyless_common::input_processing::config::CircuitConfig;
-use figment::{
-    Figment,
-    providers::{Env, Format, Yaml},
-};
+use figment::{providers::Env, Figment};
 use rust_rapidsnark::FullProver;
 use serde::{Deserialize, Serialize};
 
-use crate::config::{self, CONFIG, ProverServiceConfig};
+use crate::config::{ProverServiceConfig, CONFIG};
 use crate::groth16_vk::OnChainGroth16VerificationKey;
 use crate::prover_key::TrainingWheelsKeyPair;
-use std::env;
 use tokio::sync::Mutex;
-use tracing::info;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProverServiceSecrets {

--- a/prover/src/state.rs
+++ b/prover/src/state.rs
@@ -1,13 +1,13 @@
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_keyless_common::input_processing::config::CircuitConfig;
 use figment::{
-    providers::{Env, Format, Yaml},
     Figment,
+    providers::{Env, Format, Yaml},
 };
 use rust_rapidsnark::FullProver;
 use serde::{Deserialize, Serialize};
 
-use crate::config::{self, ProverServiceConfig};
+use crate::config::{self, CONFIG, ProverServiceConfig};
 use crate::groth16_vk::OnChainGroth16VerificationKey;
 use crate::prover_key::TrainingWheelsKeyPair;
 use std::env;
@@ -37,18 +37,6 @@ pub struct ProverServiceState {
 
 impl ProverServiceState {
     pub fn init() -> Self {
-        let config_file_path = env::var(config::CONFIG_FILE_PATH_ENVVAR)
-            .unwrap_or(String::from(config::CONFIG_FILE_PATH));
-
-        // read config and secret key
-        let config: ProverServiceConfig = Figment::new()
-            .merge(Yaml::file(config_file_path))
-            .merge(Env::raw())
-            .extract()
-            .expect("Couldn't load config");
-
-        info!("Prover config loaded: {:?}", config);
-
         let ProverServiceSecrets {
             private_key_0: private_key,
             private_key_1: private_key_new,
@@ -58,18 +46,18 @@ impl ProverServiceState {
             .expect("Couldn't load private key from environment variable PRIVATE_KEY");
 
         let default_circuit = SetupSpecificState {
-            config: config.load_circuit_config(false),
-            groth16_vk: config.load_vk(false),
+            config: CONFIG.load_circuit_params(false),
+            groth16_vk: CONFIG.load_vk(false),
             tw_keys: TrainingWheelsKeyPair::from_sk(private_key),
-            full_prover: Mutex::new(FullProver::new(&config.zkey_path(false)).unwrap()),
+            full_prover: Mutex::new(FullProver::new(&CONFIG.zkey_path(false)).unwrap()),
         };
 
-        let new_circuit = if config.new_setup_dir.is_some() {
+        let new_circuit = if CONFIG.new_setup_dir.is_some() {
             let state = SetupSpecificState {
-                config: config.load_circuit_config(true),
-                groth16_vk: config.load_vk(true),
+                config: CONFIG.load_circuit_params(true),
+                groth16_vk: CONFIG.load_vk(true),
                 tw_keys: TrainingWheelsKeyPair::from_sk(private_key_new.unwrap()),
-                full_prover: Mutex::new(FullProver::new(&config.zkey_path(true)).unwrap()),
+                full_prover: Mutex::new(FullProver::new(&CONFIG.zkey_path(true)).unwrap()),
             };
             Some(state)
         } else {
@@ -77,7 +65,7 @@ impl ProverServiceState {
         };
 
         ProverServiceState {
-            config,
+            config: CONFIG.clone(),
             default_setup: default_circuit,
             new_setup: new_circuit,
         }


### PR DESCRIPTION
## The change

Add an endpoint `/meta` that returns git commit and config.
This should make future troubleshooting/deployment verifying easier.

Example response:
```json
{
    "git_commit": null,
    "default_setup_dir": "default",
    "new_setup_dir": "new",
    "resources_dir": "~/.local/share/aptos-prover-service",
    "zkey_filename": "prover_key.zkey",
    "test_verification_key_filename": "verification_key.json",
    "witness_gen_binary_filename": "main_c",
    "oidc_providers": [
        {
            "iss": "https://accounts.google.com",
            "endpoint_url": "https://www.googleapis.com/oauth2/v3/certs"
        },
        {
            "iss": "test.oidc.provider",
            "endpoint_url": "https://github.com/aptos-labs/aptos-core/raw/main/types/src/jwks/rsa/insecure_test_jwk.json"
        },
        {
            "iss": "test.federated.oidc.provider",
            "endpoint_url": "https://github.com/aptos-labs/aptos-core/raw/main/types/src/jwks/rsa/secure_test_jwk.json"
        }
    ],
    "jwk_refresh_rate_secs": 10,
    "port": 8083,
    "metrics_port": 9100,
    "enable_dangerous_logging": true,
    "enable_debug_checks": true,
    "enable_test_provider": true,
    "enable_federated_jwks": true,
    "disable_iat_in_past_check": false,
    "use_insecure_jwk_for_test": false
}
```

## Some Implementation notes.
- `ProverServiceConfig` are now stored in a global variable `CONFIG` for concurrent access.
- docker build workflow now passes the git commit into the image.
- Prover process now expects envvar `GIT_COMMIT`.
- Some misc Dockerfile and function name clean-up are also done in this PR.
