### PR TITLE
Make exp claim check configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This repo contains:
 1. The `circom` implementation of the Aptos Keyless ZK relation from AIP-61
 2. An implementation of a ZK proving service
+
+## Submodules
+
+This repository uses a Git submodule for its [`rust-rapdisnark`](https://github.com/aptos-labs/rust-rapidsnark) dependency.
+You should pull it via:
+
+```
+git submodule init
+git submodule update
+```

--- a/prover/config.yml
+++ b/prover/config.yml
@@ -17,5 +17,5 @@ metrics_port: 9100
 enable_dangerous_logging: false
 enable_debug_checks: false
 enable_federated_jwks: false
-disable_exp_claim_in_future_check: false
-disable_iat_in_past_check: false
+enable_jwt_exp_not_in_the_past_check: true
+enable_jwt_iat_not_in_future_check: true

--- a/prover/config.yml
+++ b/prover/config.yml
@@ -17,3 +17,5 @@ metrics_port: 9100
 enable_dangerous_logging: false
 enable_debug_checks: false
 enable_federated_jwks: false
+disable_valid_jwt_exp_claim_check: false
+disable_iat_in_past_check: false

--- a/prover/config.yml
+++ b/prover/config.yml
@@ -17,5 +17,5 @@ metrics_port: 9100
 enable_dangerous_logging: false
 enable_debug_checks: false
 enable_federated_jwks: false
-disable_valid_jwt_exp_claim_check: false
+disable_exp_claim_in_future_check: false
 disable_iat_in_past_check: false

--- a/prover/config_local_testing.yml
+++ b/prover/config_local_testing.yml
@@ -19,5 +19,5 @@ enable_dangerous_logging: true
 enable_debug_checks: true
 enable_test_provider: true
 enable_federated_jwks: true
-disable_iat_in_past_check: false
+enable_jwt_iat_not_in_future_check: true
 use_insecure_jwk_for_test: true

--- a/prover/config_local_testing_new_setup_specified.yml
+++ b/prover/config_local_testing_new_setup_specified.yml
@@ -19,4 +19,4 @@ enable_dangerous_logging: true
 enable_debug_checks: true
 enable_test_provider: true
 enable_federated_jwks: true
-disable_iat_in_past_check: false
+enable_jwt_iat_not_in_future_check: true

--- a/prover/config_local_testing_new_setup_unspecified.yml
+++ b/prover/config_local_testing_new_setup_unspecified.yml
@@ -18,4 +18,4 @@ enable_dangerous_logging: true
 enable_debug_checks: true
 enable_test_provider: true
 enable_federated_jwks: true
-disable_iat_in_past_check: false
+enable_jwt_iat_not_in_future_check: true

--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -38,6 +38,8 @@ pub struct ProverServiceConfig {
     #[serde(default)]
     pub disable_iat_in_past_check: bool,
     #[serde(default)]
+    pub disable_valid_jwt_exp_claim_check: bool,
+    #[serde(default)]
     pub use_insecure_jwk_for_test: bool,
 }
 

--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -38,7 +38,7 @@ pub struct ProverServiceConfig {
     #[serde(default)]
     pub disable_iat_in_past_check: bool,
     #[serde(default)]
-    pub disable_valid_jwt_exp_claim_check: bool,
+    pub disable_exp_claim_in_future_check: bool,
     #[serde(default)]
     pub use_insecure_jwk_for_test: bool,
 }

--- a/prover/src/config.rs
+++ b/prover/src/config.rs
@@ -12,6 +12,10 @@ pub const CONFIG_FILE_PATH: &str = "config.yml";
 pub const LOCAL_TESTING_CONFIG_FILE_PATH: &str = "config_local_testing.yml";
 pub const CONFIG_FILE_PATH_ENVVAR: &str = "CONFIG_FILE";
 
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 //#[serde(deny_unknown_fields)]
 pub struct ProverServiceConfig {
@@ -35,10 +39,10 @@ pub struct ProverServiceConfig {
     pub enable_test_provider: bool,
     #[serde(default)]
     pub enable_federated_jwks: bool,
-    #[serde(default)]
-    pub disable_iat_in_past_check: bool,
-    #[serde(default)]
-    pub disable_exp_claim_in_future_check: bool,
+    #[serde(default = "default_true")]
+    pub enable_jwt_iat_not_in_future_check: bool,
+    #[serde(default = "default_true")]
+    pub enable_jwt_exp_not_in_the_past_check: bool,
     #[serde(default)]
     pub use_insecure_jwk_for_test: bool,
 }

--- a/prover/src/handlers.rs
+++ b/prover/src/handlers.rs
@@ -55,12 +55,8 @@ pub async fn prove_handler(
         jwk_override = get_jwk(&body.jwt_b64, "https://github.com/aptos-labs/aptos-core/raw/main/types/src/jwks/rsa/insecure_test_jwk.json").await.ok().map(|arc| (*arc).clone());
     }
 
-    training_wheels::validate_jwt_sig_and_dates(
-        &body,
-        jwk_override.as_ref(),
-        state.config.disable_iat_in_past_check,
-    )
-    .with_status(StatusCode::BAD_REQUEST)?;
+    training_wheels::validate_jwt_sig_and_dates(&body, jwk_override.as_ref(), &state.config)
+        .with_status(StatusCode::BAD_REQUEST)?;
 
     let input = preprocess::decode_and_add_jwk(body, jwk_override.as_ref())
         .with_status(StatusCode::BAD_REQUEST)?;

--- a/prover/src/tests/training_wheels.rs
+++ b/prover/src/tests/training_wheels.rs
@@ -1,5 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::config::ProverServiceConfig;
 use crate::config::CONFIG;
 use crate::tests::common::types::{ProofTestCase, TestJWTPayload};
 use crate::tests::common::{gen_test_jwk_keypair, get_test_circuit_config, types::TestJWKKeyPair};

--- a/prover/src/tests/training_wheels.rs
+++ b/prover/src/tests/training_wheels.rs
@@ -16,7 +16,7 @@ fn test_jwt_validation(jwt_payload: TestJWTPayload, config: &ProverServiceConfig
     assert!(validate_jwt_sig_and_dates(
         &prover_request_input,
         Some(&jwk_keypair.into_rsa_jwk()),
-        &config,
+        config,
     )
     .is_ok());
 }

--- a/prover/src/tests/training_wheels.rs
+++ b/prover/src/tests/training_wheels.rs
@@ -71,7 +71,7 @@ fn test_validate_jwt_sig_and_dates_expired_can_be_disabled() {
     let prover_request_input = testcase.convert_to_prover_request(&jwk_keypair);
 
     let mut config = CONFIG.clone();
-    config.disable_valid_jwt_exp_claim_check = true;
+    config.disable_exp_claim_in_future_check = true;
 
     assert!(validate_jwt_sig_and_dates(
         &prover_request_input,

--- a/prover/src/tests/training_wheels.rs
+++ b/prover/src/tests/training_wheels.rs
@@ -71,7 +71,7 @@ fn test_validate_jwt_sig_and_dates_expired_can_be_disabled() {
     let prover_request_input = testcase.convert_to_prover_request(&jwk_keypair);
 
     let mut config = CONFIG.clone();
-    config.disable_exp_claim_in_future_check = true;
+    config.enable_jwt_exp_not_in_the_past_check = false;
 
     assert!(validate_jwt_sig_and_dates(
         &prover_request_input,
@@ -129,8 +129,8 @@ fn test_validate_jwt_sig_and_dates_future_iat_can_be_disabled() {
     let prover_request_input = testcase.convert_to_prover_request(&jwk_keypair);
 
     let mut config = CONFIG.clone();
-    config.disable_iat_in_past_check = true;
     // Disable the future iat check.
+    config.enable_jwt_iat_not_in_future_check = false;
     assert!(validate_jwt_sig_and_dates(
         &prover_request_input,
         Some(&jwk_keypair.into_rsa_jwk()),

--- a/prover/src/training_wheels/verification_logic.rs
+++ b/prover/src/training_wheels/verification_logic.rs
@@ -65,7 +65,7 @@ pub fn validate_jwt_sig_and_dates(
 
     // Check the signature verifies.
     let mut validation = Validation::new(Algorithm::RS256);
-    if config.disable_valid_jwt_exp_claim_check {
+    if config.disable_exp_claim_in_future_check {
         validation.validate_exp = false;
     }
     let key = &DecodingKey::from_rsa_components(&jwk.n, &jwk.e)?;

--- a/prover/src/training_wheels/verification_logic.rs
+++ b/prover/src/training_wheels/verification_logic.rs
@@ -65,7 +65,7 @@ pub fn validate_jwt_sig_and_dates(
 
     // Check the signature verifies.
     let mut validation = Validation::new(Algorithm::RS256);
-    if config.disable_exp_claim_in_future_check {
+    if !config.enable_jwt_exp_not_in_the_past_check {
         validation.validate_exp = false;
     }
     let key = &DecodingKey::from_rsa_components(&jwk.n, &jwk.e)?;
@@ -79,7 +79,7 @@ pub fn validate_jwt_sig_and_dates(
         .context("Went back in time")
         .with_status(StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    if !config.disable_iat_in_past_check && payload_struct.iat > since_the_epoch.as_secs() {
+    if config.enable_jwt_iat_not_in_future_check && payload_struct.iat > since_the_epoch.as_secs() {
         crate::bail!("Submitted a request jwt which was issued in the future")
     } else {
         Ok(())

--- a/prover/src/training_wheels/verification_logic.rs
+++ b/prover/src/training_wheels/verification_logic.rs
@@ -17,6 +17,7 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 
 use crate::{
     api::RequestInput,
+    config::ProverServiceConfig,
     error::{ErrorWithCode, ThrowCodeOnError},
     input_processing::{field_parser::FieldParser, types::Input},
     jwk_fetching,
@@ -43,7 +44,7 @@ pub fn check_nonce_consistency(input: &Input, circuit_config: &CircuitConfig) ->
 pub fn validate_jwt_sig_and_dates(
     rqi: &RequestInput,
     maybe_jwk: Option<&RSA_JWK>,
-    disable_iat_in_past_check: bool,
+    config: &ProverServiceConfig,
 ) -> Result<(), ErrorWithCode> {
     let jwt_parts = JwtParts::from_b64(&rqi.jwt_b64)?;
 
@@ -64,7 +65,9 @@ pub fn validate_jwt_sig_and_dates(
 
     // Check the signature verifies.
     let mut validation = Validation::new(Algorithm::RS256);
-    validation.validate_exp = false;
+    if config.disable_valid_jwt_exp_claim_check {
+        validation.validate_exp = false;
+    }
     let key = &DecodingKey::from_rsa_components(&jwk.n, &jwk.e)?;
 
     let _claims = jsonwebtoken::decode::<Claims>(&rqi.jwt_b64, key, &validation)?;
@@ -76,7 +79,7 @@ pub fn validate_jwt_sig_and_dates(
         .context("Went back in time")
         .with_status(StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    if !disable_iat_in_past_check && payload_struct.iat > since_the_epoch.as_secs() {
+    if !config.disable_iat_in_past_check && payload_struct.iat > since_the_epoch.as_secs() {
         crate::bail!("Submitted a request jwt which was issued in the future")
     } else {
         Ok(())


### PR DESCRIPTION
The JWT `exp` claim check defaults to on, but can be disabled via config file by setting `disable_exp_claim_in_future_check = true`