### PR TITLE
restore unused templates in circom code to make May 2024 ceremony verifiable

### DIFF
--- a/circuit/templates/helpers/arrays.circom
+++ b/circuit/templates/helpers/arrays.circom
@@ -269,6 +269,9 @@ template ConcatenationCheck(maxFullStringLen, maxLeftStringLen, maxRightStringLe
 template CheckAreASCIIDigits(maxNumDigits) {
     signal input in[maxNumDigits];
     signal input len;
+    for (var i = 0; i < maxNumDigits; i++) {
+        log(in[i]);
+    }
     
     signal selector[maxNumDigits] <== ArraySelector(maxNumDigits)(0, len);
     for (var i = 0; i < maxNumDigits; i++) {
@@ -321,3 +324,39 @@ template ASCIIDigitsToField(maxLen) {
     out <== accumulators[maxLen - 1];
 }
 
+// Given arrays `one` and `two`, which are both 0-padded after `len`, check that `one[0:len]` is the reverse of `two[0:len]`
+template ReverseCheck(maxStrLen) {
+    signal input one[maxStrLen];
+    signal input two[maxStrLen];
+    signal input len;
+
+    signal one_hash <== HashBytesToField(maxStrLen)(one);
+    signal two_hash <== HashBytesToField(maxStrLen)(two);
+    signal random_challenge <== Poseidon(3)([one_hash, two_hash, len]);
+    
+    signal challenge_powers[maxStrLen];
+    challenge_powers[0] <== 1;
+    challenge_powers[1] <== random_challenge;
+    for (var i = 2; i < maxStrLen; i++) {
+       challenge_powers[i] <== challenge_powers[i-1] * random_challenge; 
+    } 
+
+    signal one_poly[maxStrLen];
+    for (var i = 0; i < maxStrLen; i++) {
+       one_poly[i] <== one[i] * challenge_powers[i];
+    }
+
+    signal two_poly[maxStrLen];
+    for (var i = 0; i < maxStrLen; i++) {
+        var idx = maxStrLen-i-1; // Challenge powers are reversed
+        two_poly[i] <== two[idx] * challenge_powers[i];
+    }
+    var two_zero_pad_len = maxStrLen-len;
+
+    signal one_poly_eval <== CalculateTotal(maxStrLen)(one_poly);
+    signal two_poly_eval <== CalculateTotal(maxStrLen)(two_poly); 
+    
+    var distinguishing_value = SelectArrayValue(maxStrLen)(challenge_powers, two_zero_pad_len);
+
+    one_poly_eval * distinguishing_value === two_poly_eval;
+}

--- a/circuit/templates/helpers/base64.circom
+++ b/circuit/templates/helpers/base64.circom
@@ -62,7 +62,7 @@ template Base64URLLookup() {
     signal sum_underscore <== sum_minus + equal_underscore.out * 63;
 
     out <== sum_underscore;
-    //log("sum_underscore (out): ", out);
+    log("sum_underscore (out): ", out);
 
     // '='
     component equal_eqsign = IsZero();
@@ -73,14 +73,14 @@ template Base64URLLookup() {
     zero_padding.in <== in;
 
 
-    //log("zero_padding.out: ", zero_padding.out);
-    //log("equal_eqsign.out: ", equal_eqsign.out);
-    //log("equal_underscore.out: ", equal_underscore.out);
-    //log("equal_minus.out: ", equal_minus.out);
-    //log("range_09: ", range_09);
-    //log("range_az: ", range_az);
-    //log("range_AZ: ", range_AZ);
-    //log("< end Base64URLLookup");
+    log("zero_padding.out: ", zero_padding.out);
+    log("equal_eqsign.out: ", equal_eqsign.out);
+    log("equal_underscore.out: ", equal_underscore.out);
+    log("equal_minus.out: ", equal_minus.out);
+    log("range_09: ", range_09);
+    log("range_az: ", range_az);
+    log("range_AZ: ", range_AZ);
+    log("< end Base64URLLookup");
 
     signal result <== range_AZ + range_az + range_09 + equal_minus.out + equal_underscore.out + equal_eqsign.out + zero_padding.out;
     1 === result;
@@ -107,8 +107,8 @@ template Base64Decode(N) {
         for (var j = 0; j < 4; j++) {
             bits_in[i\4][j] = Num2Bits(6);
 
-            //log(">> calling into Base64URLLookup");
-            //log("translate[i\\4][j].in: ", in[i+j]);
+            log(">> calling into Base64URLLookup");
+            log("translate[i\\4][j].in: ", in[i+j]);
 
             translate[i\4][j] = Base64URLLookup();
             translate[i\4][j].in <== in[i+j];

--- a/circuit/templates/helpers/misc.circom
+++ b/circuit/templates/helpers/misc.circom
@@ -39,6 +39,19 @@ template CalculateTotal(n) {
     sum <== sums[n - 1];
 }
 
+// Checks `input_not_ascii` is the digit representation of ascii digit string `input_ascii`
+// Assumes both inputs contain only digits
+template DigitStringAsciiEquivalenceCheck(maxInputLen) {
+    signal input input_ascii[maxInputLen];
+    signal input input_not_ascii[maxInputLen];
+    signal input len;
+
+    signal selector_bits[maxInputLen] <== RightArraySelector(maxInputLen)(len-1);
+    for (var i = 0; i < maxInputLen; i++) {
+        ((input_ascii[i]-48)-input_not_ascii[i])*(1-selector_bits[i]) === 0;
+    }
+}
+
 // Given input `in`, enforces that `in[0] === in[1]` if `bool` is 1
 template AssertEqualIfTrue() {
     signal input in[2];
@@ -98,9 +111,7 @@ template EmailVerifiedCheck(maxEVNameLen, maxEVValueLen, maxUIDNameLen) {
     }
 }
 
-// Given an array of ascii characters representing a JSON object, output a binary array demarquing 
-//  input = { asdfsdf "asdf" }
-// output = 000000000001111000
+
 template StringBodies(len) {
   signal input in[len];
   signal output out[len];
@@ -128,22 +139,19 @@ template StringBodies(len) {
   for (var i = 1; i < len; i++) {
     var is_quote = IsEqual()([in[i], 34]); 
     var prev_is_odd_backslash = adjacent_backslash_parity[i-1];
-    quotes[i] <== is_quote * (1 - prev_is_odd_backslash); // 1 iff there is a non-escaped quote at this position
-    quote_parity_1[i] <== quotes[i] * (1 - quote_parity[i-1]); // 1 iff quotes[i] == 1 and quote_parity[i-1] == 0, else 0
-    quote_parity_2[i] <== (1 - quotes[i]) * quote_parity[i-1]; // 1 iff quotes[i] == 0 and quote_party[i-1] == 1, else 0
-    quote_parity[i] <== quote_parity_1[i] + quote_parity_2[i]; // Or of previous two, i.e., XOR(quotes[i], quote_parity[i-1])
+    quotes[i] <== is_quote * (1 - prev_is_odd_backslash);
+    quote_parity_1[i] <== quotes[i] * (1 - quote_parity[i-1]);
+    quote_parity_2[i] <== (1 - quotes[i]) * quote_parity[i-1];
+    quote_parity[i] <== quote_parity_1[i] + quote_parity_2[i];
   }
-  //  input = { asdfsdf "asdf" }
-  // output = 000000000011111000
-  // i.e., still has offset-by-one error
+
 
   out[0] <== 0;
 
   for (var i = 1; i < len; i++) {
-    out[i] <== AND()(quote_parity[i-1], quote_parity[i]); // remove offset error
+    out[i] <== AND()(quote_parity[i-1], quote_parity[i]);
   }
 }
-
 
 
 // Given a base64-encoded array `in`, max length `maxN`, and actual unpadded length `n`, returns

--- a/circuit/templates/helpers/packing.circom
+++ b/circuit/templates/helpers/packing.circom
@@ -52,6 +52,21 @@ template BytesToBits(inputLen) {
     }
 }
 
+// Assumes decimals fit into a single 254 bit value when using BN254
+template ASCIIDecimalsToFieldElem(inputLen) {
+    signal input in[inputLen];
+    signal output out;
+
+    var lc1 = in[0];
+     
+    var e2 = 10;
+    for (var i = 1; i<inputLen; i++) {
+        lc1 += in[i] * e2;
+        e2 = e2 * 10;
+    }
+
+    lc1 ==> out;
+}
 
 // Converts bit array 'in' into an array of field elements of size `bitsPerFieldElem` each
 // Example: with inputLen=11, bitsPerFieldElem=4, [0,0,0,0, 0,0,0,1, 0,1,1,] ==> [0, 1, 6]
@@ -91,3 +106,43 @@ template BitsToFieldElems(inputLen, bitsPerFieldElem) {
     bits_2_num_be[num_elems-1].out ==> elems[num_elems-1];
 }
 
+// Assumes `in` is a little endian bit array where `48` corresponds to `0` and `49` corresponds to `1`
+// Packs a maximum of `maxBitsPerFieldElem` bits per field element, actually packs `to_pack_len`
+// TODO: Not tested for more than one field element. We only ever use it to pack one field element anyways
+template AsciiBitsLEToFieldElems(inputLen, maxBitsPerFieldElem) {
+    signal input in[inputLen];
+    signal input to_pack_len;
+    signal selector_bits[inputLen] <== ArraySelector(inputLen)(0, to_pack_len);
+    var num_elems = inputLen%maxBitsPerFieldElem == 0 ? inputLen \ maxBitsPerFieldElem : (inputLen\maxBitsPerFieldElem) + 1; // '\' is the quotient operation - we add 1 if there are extra bits past the full bytes
+    signal output elems[num_elems];
+    component bits_2_num_be[num_elems]; 
+    for (var i = 0; i < num_elems-1; i++) {
+        bits_2_num_be[i] = Bits2Num(maxBitsPerFieldElem); // assign circuit component
+    }
+
+    // If we have an extra byte that isn't full of bits, we truncate the Bits2NumBigEndian component size for that byte. This is equivalent to 0 padding the end of the array
+    var num_extra_bits = inputLen % maxBitsPerFieldElem;
+    if (num_extra_bits == 0) {
+        num_extra_bits = maxBitsPerFieldElem; // The last field element is full
+        bits_2_num_be[num_elems-1] = Bits2Num(maxBitsPerFieldElem);
+    } else {
+        bits_2_num_be[num_elems-1] = Bits2Num(num_extra_bits);
+    }
+
+    // Assign all but the last field element
+    for (var i = 0; i < num_elems-1; i++) {
+        for (var j = 0; j < maxBitsPerFieldElem; j++) {
+            var index = (i * maxBitsPerFieldElem) + j;
+            bits_2_num_be[i].in[j] <== in[index]-48 * selector_bits[index];
+        }
+        bits_2_num_be[i].out ==> elems[i];
+    }
+
+    // Assign the last field element
+    var i = num_elems-1;
+    for (var j = 0; j < num_extra_bits; j++) {
+        var index = (i*maxBitsPerFieldElem) + j;
+        bits_2_num_be[num_elems-1].in[j] <== in[index]-48 * selector_bits[index];
+    }
+    bits_2_num_be[i].out ==> elems[i];
+}

--- a/circuit/templates/rsa_test.circom
+++ b/circuit/templates/rsa_test.circom
@@ -1,0 +1,35 @@
+pragma circom 2.1.3;
+
+include "helpers/base64.circom";
+include "helpers/slice.circom";
+include "helpers/arrays.circom";
+include "helpers/misc.circom";
+include "helpers/packing.circom";
+include "helpers/hashtofield.circom";
+include "helpers/sha.circom";
+include "../node_modules/circomlib/circuits/sha256/sha256.circom";
+//include "../doubleblind-xyz/circuits/rsa.circom";
+include "../circom-rsa-verify/circuits/rsa_verify.circom";
+include "../node_modules/circomlib/circuits/poseidon.circom";
+include "../node_modules/circomlib/circuits/bitify.circom";
+
+
+template test_rsa() {
+
+    signal input sig[32];
+    signal input mod[32];
+    signal input hash[4];
+
+    RsaVerifyPkcs1v15(64, 32)(sig, mod, hash);
+
+//    signal input a[2];
+//    signal input b[2];
+//    signal input mod[2];
+//
+//    signal out[2] <== FpMul(64, 2)(a, b, mod);
+//    log(out[0]);
+//    log(out[1]);
+
+}
+
+component main = test_rsa(); 


### PR DESCRIPTION
# Description

## What is the change being pushed?

This sets back the circom circuit code to be (somewhat) consistent with the old one from `aptos-core`, at the May 2024 ceremony commit [`39f9c44b4342ed5e6941fae36cf6c87c52b1e17f `](https://github.com/aptos-labs/aptos-core/commits/39f9c44b4342ed5e6941fae36cf6c87c52b1e17f).

Specifically, it reintroduces some old unused circom templates, some `log` statements and removes some comments.

This way, we can re-produce the May 2024 ceremony's R1CS in this repo. (It's weird that circom compilation is sensitive to code re-organization such as removing unused templates.)

After this PR merges, we will instantly revert it. Then, we can cut our first `circuit-release-v1.0` branch and tag the May 2024 release with tag `circuit-v1.0.0`.

Btw, the desired R1CS `b2sum` hash for v1.0.0 is:

```
9e9bb596c7a453521e9b8df1dbd82c0bad5788f2679f8c53a6bc6112b9ec6061fea36547efa649ba9af78f6792ecd639a654ea6a1d11553b1ce93998924b3ac2
```

cc @zjma and @rex1fernando: just giving you a heads up here, since this change will be reverted!

## Why are you pushing this change?

To maintain a nice invariant in this repo: all past circuit ceremonies will have a release branch and a publicly-verifiable GitHub release in this repo.

## How is this implemented?

N/A.

# Type of Change

Select one or more for each category, as applicable.

Or, introduce your own, if needed.

## Circuit change

 - [x] No-op circuit change

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all keyless stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
