### PR TITLE
Update rand_big() precondition

### DIFF
--- a/circuit/src/bigint.rs
+++ b/circuit/src/bigint.rs
@@ -8,8 +8,10 @@ use aptos_keyless_common::input_processing::{
 use aptos_logger::info;
 use rand::{thread_rng, Rng};
 
-/// Given a non-negative integer `x`, generate a non-negative integer `y` that satisfies `y < x`.
+/// Given a positive integer `x`, generate a non-negative integer `y` that satisfies `y < x`.
 /// `x` and `y` are both encoded to byte array with the most significant byte first.
+///
+/// The caller needs to ensure `x` is positive.
 fn rand_big<R: Rng>(rng: &mut R, x_bytes_be: &[u8]) -> Vec<u8> {
     let n = x_bytes_be.len();
     let non_zero_idxs: Vec<usize> = x_bytes_be


### PR DESCRIPTION
# Description

Update the invariant of a test-only function `rand_big`.

## What is the change being pushed?

`rand_big()` was commented to take a non-negative `x` as input,
while it should assume `x` is a positive integer.
Calling this out in the function comment.

## Why are you pushing this change?

The current comment is misleading.

## How is this implemented?

Comments are updated.

# Type of Change

Tiny refactoring.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all keyless stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
