### PR TITLE
add support for audless accounts and fix nested JSON parsing bugs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
-# Description
-
-## What is the change being pushed?
+# What is the change being pushed?
 
 <!--
  Describe **what** the change is. e.g.,:
@@ -33,20 +31,23 @@
   - highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
 -->
 
-# Type of Change
+# Type of change
 
+<!-- 
 Select one or more for each category, as applicable.
-
+Delete the category, if not applicable.
 Or, introduce your own, if needed.
+-->
 
-## Circuit change
+**Circuit change?**
 
+- [ ] New circuit feature
 - [ ] Circuit correctness fix
 - [ ] Circuit soundness fix
 - [ ] Circuit test cases
 - [ ] Circuit benchmarks
 
-## Prover service change
+**Prover service change?**
 
 - [ ] New feature
 - [ ] Bug fix

--- a/circuit/src/arrays.rs
+++ b/circuit/src/arrays.rs
@@ -1520,7 +1520,7 @@ fn ascii_digits_to_field_out_of_bounds_test() {
         .unwrap();
 
     let result = circuit_handle.gen_witness(circuit_input_signals);
-    assert!(result.is_ok());
+    assert!(result.is_err());
 }
 
 #[test]

--- a/circuit/src/bigint.rs
+++ b/circuit/src/bigint.rs
@@ -83,7 +83,9 @@ fn common<F: FnMut() -> (Vec<u8>, Vec<u8>)>(mut a_b_provider: F, expected_output
         let b_bytes_le: Vec<u8> = b_bytes_be.into_iter().rev().collect();
         let b_limbs_le = bytes_le_into_limbs_le(b_bytes_le);
 
-        let config = CircuitConfig::new().max_length("a", 32).max_length("b", 32);
+        let config = CircuitConfig::new()
+            .max_length("a", 32)
+            .max_length("b", 32);
         let circuit_input_signals = CircuitInputSignals::new()
             .limbs_input("a", a_limbs_le.as_slice())
             .limbs_input("b", b_limbs_le.as_slice())

--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -38,7 +38,7 @@ impl TestCircuitHandle {
     /// Compile the circuit in the given file using BN254 as the underlying curve.
     pub fn new(file_name: &str) -> anyhow::Result<Self> {
         let cargo_manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-        let include_root_dir = cargo_manifest_dir.join("templates");
+        let include_root_dir = cargo_manifest_dir.join("./templates");
         let src_circuit_path = include_root_dir.join("tests").join(file_name);
         let content = fs::read_to_string(src_circuit_path)?;
         Self::new_from_str(content.as_str())
@@ -66,8 +66,8 @@ impl TestCircuitHandle {
                 dir.path().to_str().unwrap(),
             ])
             .output()?;
-        println!("circom_stdout={}", String::from_utf8_lossy(&output.stdout));
-        println!("circom_stderr={}", String::from_utf8_lossy(&output.stderr));
+        println!("{}", String::from_utf8_lossy(&output.stdout));
+        println!("{}", String::from_utf8_lossy(&output.stderr));
         ensure!(output.status.success());
         Ok(Self { dir })
     }

--- a/circuit/templates/helpers/base64.circom
+++ b/circuit/templates/helpers/base64.circom
@@ -86,8 +86,11 @@ template Base64URLLookup() {
     1 === result;
 }
 
+// Takes in an array `in` of Base64URL characters and decodes it to ASCII characters in `out`. `in` may be
+// 0-padded after its base64 elements
+// Assumes `in` contains only Base64URL characters followed by 0-padding
 template Base64Decode(N) {
-    //var N = ((3*M)\4)+2; // TODO: Make sure this is ok
+    //var N = ((3*M)\4)+2; // Rough inverse of the computation performed to compute M
     var M = 4*((N+2)\3);
     signal input in[M];
     signal output out[N];

--- a/circuit/templates/helpers/jwt_field_parsing.circom
+++ b/circuit/templates/helpers/jwt_field_parsing.circom
@@ -7,64 +7,101 @@ include "./packing.circom";
 include "circomlib/circuits/gates.circom";
 include "circomlib/circuits/bitify.circom";
 
+// Takes as input a string `field` corresponding to the field of a JSON name+value pair.
+// It is enforced that `field` has the structure: []name[]':'[]value[](','|'}'),
+// where [] refers to arbitrary characters, name and value refer to the
+// input fields with the same names, 'x' denotes a specific character, and | denotes
+// that either character may be included
+//
+// It is assumed that `skip_checks` is equal to 0 or to 1. If it is 1, all
+// checks enforced by this template will be skipped, and it will function as
+// a no-op. If it is set to 0, failing one check will fail proof generation
+//
+// Assumes `field_len` is the length of `field` followed by 0-padding, `name_len` is
+// the length of `name` before 0-padding, `value_len` is the length of `value` before 0-padding
+//
+// Note that this template is NOT secure on its own, but must be called from
+// `ParseJWTFieldWithQuotedValue` or `ParseJWTFieldWithUnquotedValue`
 template ParseJWTFieldSharedLogic(maxKVPairLen, maxNameLen, maxValueLen) {
     signal input field[maxKVPairLen]; // ASCII
-    signal input name[maxNameLen];
-    signal input value[maxValueLen];
-    signal input field_len; // ASCII
+    signal input name[maxNameLen]; // ASCII
+    signal input value[maxValueLen]; // ASCII
+    signal input field_len;
     signal input name_len;
     signal input value_index; // index of value within `field`
     signal input value_len;
     signal input colon_index; // index of colon within `field`
+    signal input skip_checks; // don't fail if any checks fail in this subcircuit
 
+    signal checks[9];
     // Enforce that end of name < colon < start of value and that field_len >=
     // name_len + value_len + 1 (where the +1 is for the colon), so that the
     // parts of the JWT field are in the correct order
     signal colon_greater_name <== LessThan(20)([name_len, colon_index]);
-    colon_greater_name === 1;
+    checks[0] <== IsEqual()([colon_greater_name, 1]);
+
     signal colon_less_value <== LessThan(20)([colon_index, value_index]);
-    colon_less_value === 1;
+    checks[1] <== IsEqual()([colon_less_value, 1]);
+
     signal field_len_ok <== GreaterEqThan(20)([field_len, name_len + value_len + 1]);
-    field_len_ok === 1;
+    checks[2] <== IsEqual()([field_len_ok, 1]);
 
     signal field_hash <== HashBytesToFieldWithLen(maxKVPairLen)(field, field_len);
 
     signal name_first_quote <== SelectArrayValue(maxKVPairLen)(field, 0);
-    name_first_quote === 34; // '"'
-    CheckSubstrInclusionPoly(maxKVPairLen, maxNameLen)(field, field_hash, name, name_len, 1);
+    checks[3] <== IsEqual()([name_first_quote, 34]); // '"'
+
+    checks[4] <== CheckSubstrInclusionPolyBoolean(maxKVPairLen, maxNameLen)(field, field_hash, name, name_len, 1);
+
     signal name_second_quote <== SelectArrayValue(maxKVPairLen)(field, name_len+1);
-    name_second_quote === 34; // '"'
+    checks[5] <== IsEqual()([name_second_quote, 34]); // '"'
 
     signal colon <== SelectArrayValue(maxKVPairLen)(field, colon_index);
-    colon === 58; // ':'
+    checks[6] <== IsEqual()([colon, 58]); // ':'
 
-    CheckSubstrInclusionPoly(maxKVPairLen, maxValueLen)(field, field_hash, value, value_len, value_index);
+    checks[7] <== CheckSubstrInclusionPolyBoolean(maxKVPairLen, maxValueLen)(field, field_hash, value, value_len, value_index);
 
     // Enforce last character of `field` is comma or end brace
     signal last_char <== SelectArrayValue(maxKVPairLen)(field, field_len-1);
-    (last_char - 44) * (last_char - 125) === 0; // ',' or '}'
+    checks[8] <== IsEqual()([(last_char - 44) * (last_char - 125),0]); // ',' or '}'
+
+    signal checks_pass <== MultiAND(9)(checks);
+    signal success <== OR()(checks_pass, skip_checks);
+    success === 1;
 }
 
-// Checks the given jwt key value pair has a colon in between the name and value, a comma or endbrace at the end, and only whitespace in between the name and colon, colon and value, and value and end character. Returns the name and value fields 
-// We did this instead of a polynomial concatenation check to avoid having to implement a multi-variable concatenation check
+// Takes as input a string `field` corresponding to the field of a JSON name+value pair.
+// It is enforced that `field` has the structure: []name[]':'[]'"'value'"'[](','|'}'),
+// where [] refers to arbitrary whitespace characters, name and value refer to the
+// input fields with the same names, 'x' denotes a specific character, and | denotes
+// that either character may be included
+//
+// Assumes `field_len` is the length of `field` followed by 0-padding, `name_len` is
+// the length of `name` before 0-padding, `value_len` is the length of `value` before 0-padding
+//
+// It is assumed that `skip_checks` is equal to 0 or to 1. If it is 1, all
+// checks enforced by this template will be skipped, and it will function as
+// a no-op. If it is set to 0, failing one check will fail proof generation
 template ParseJWTFieldWithQuotedValue(maxKVPairLen, maxNameLen, maxValueLen) {
     signal input field[maxKVPairLen]; // ASCII
-    signal input name[maxNameLen];
-    signal input value[maxValueLen];
+    signal input name[maxNameLen]; // ASCII
+    signal input value[maxValueLen]; // ASCII
     signal input field_string_bodies[maxKVPairLen];
-    signal input field_len; // ASCII
+    signal input field_len;
     signal input name_len;
     signal input value_index; // index of value within `field`
     signal input value_len;
     signal input colon_index; // index of colon within `field`
+    signal input skip_checks;
 
-    ParseJWTFieldSharedLogic(maxKVPairLen, maxNameLen, maxValueLen)(field, name, value, field_len, name_len, value_index, value_len, colon_index);
+    ParseJWTFieldSharedLogic(maxKVPairLen, maxNameLen, maxValueLen)(field, name, value, field_len, name_len, value_index, value_len, colon_index, skip_checks);
 
+    signal checks[3];
     signal value_first_quote <== SelectArrayValue(maxKVPairLen)(field, value_index-1);
-    value_first_quote === 34; // '"'
-    signal value_second_quote <== SelectArrayValue(maxKVPairLen)(field, value_index+value_len);
-    value_second_quote === 34; // '"'
+    checks[0] <== IsEqual()([value_first_quote, 34]);
 
+    signal value_second_quote <== SelectArrayValue(maxKVPairLen)(field, value_index+value_len);
+    checks[1] <== IsEqual()([value_second_quote, 34]);
 
     // Verify whitespace is in right places, and that only name and value are inside string bodies
     signal is_whitespace[maxKVPairLen];
@@ -79,18 +116,35 @@ template ParseJWTFieldWithQuotedValue(maxKVPairLen, maxNameLen, maxValueLen) {
     signal value_selector[maxKVPairLen] <== ArraySelector(maxKVPairLen)(value_index, value_index+value_len);
 
 
+    signal whitespace_checks[3*maxKVPairLen];
     for (var i = 0; i < maxKVPairLen; i++) {
-        (whitespace_selector_one[i] + whitespace_selector_two[i] + whitespace_selector_three[i]) * (1 - is_whitespace[i]) === 0;
-        
+        whitespace_checks[3*i] <== IsEqual()([(whitespace_selector_one[i] + whitespace_selector_two[i] + whitespace_selector_three[i]) * (1 - is_whitespace[i]), 0]);
+
         // Check that only the name and value parts of the field are inside string bodies, and nothing else is
-        (name_selector[i] + value_selector[i]) * (1 - field_string_bodies[i]) === 0;
-        (1 - (name_selector[i] + value_selector[i])) * field_string_bodies[i] === 0;
+        whitespace_checks[3*i+1] <== IsEqual()([(name_selector[i] + value_selector[i]) * (1 - field_string_bodies[i]), 0]);
+
+        whitespace_checks[3*i+2] <== IsEqual()([(1 - (name_selector[i] + value_selector[i])) * field_string_bodies[i],0]);
+
     }
+    checks[2] <== MultiAND(3*maxKVPairLen)(whitespace_checks);
 
-
-
+    signal checks_pass <== MultiAND(3)(checks);
+    signal succeed <== OR()(checks_pass, skip_checks);
+    succeed === 1;
 }
 
+// Takes as input a string `field` corresponding to the field of a JSON name+value pair.
+// It is enforced that `field` has the structure: []name[]':'[]value[](','|'}'),
+// where [] refers to arbitrary whitespace characters, name and value refer to the
+// input fields with the same names, 'x' denotes a specific character, and | denotes
+// that either character may be included
+//
+// Assumes `field_len` is the length of `field` followed by 0-padding, `name_len` is
+// the length of `name` before 0-padding, `value_len` is the length of `value` before 0-padding
+//
+// It is assumed that `skip_checks` is equal to 0 or to 1. If it is 1, all
+// checks enforced by this template will be skipped, and it will function as
+// a no-op. If it is set to 0, failing one check will fail proof generation
 template ParseJWTFieldWithUnquotedValue(maxKVPairLen, maxNameLen, maxValueLen) {
     signal input field[maxKVPairLen]; // ASCII
     signal input name[maxNameLen];
@@ -100,9 +154,11 @@ template ParseJWTFieldWithUnquotedValue(maxKVPairLen, maxNameLen, maxValueLen) {
     signal input value_index; // index of value within `field`
     signal input value_len;
     signal input colon_index; // index of colon within `field`
+    signal input skip_checks;
 
-    ParseJWTFieldSharedLogic(maxKVPairLen, maxNameLen, maxValueLen)(field, name, value, field_len, name_len, value_index, value_len, colon_index);
+    ParseJWTFieldSharedLogic(maxKVPairLen, maxNameLen, maxValueLen)(field, name, value, field_len, name_len, value_index, value_len, colon_index, skip_checks);
 
+    signal checks[2];
     // Verify whitespace is in right places
     signal is_whitespace[maxKVPairLen];
     for (var i = 0; i < maxKVPairLen; i++) {
@@ -113,21 +169,41 @@ template ParseJWTFieldWithUnquotedValue(maxKVPairLen, maxNameLen, maxValueLen) {
     signal whitespace_selector_two[maxKVPairLen] <== ArraySelectorComplex(maxKVPairLen)(colon_index+1, value_index); // no quote this time, so check whitespace until the value start
     signal whitespace_selector_three[maxKVPairLen] <== ArraySelectorComplex(maxKVPairLen)(value_index+value_len, field_len-1); // and directly after the value end
 
+    signal whitespace_checks[maxKVPairLen];
     for (var i = 0; i < maxKVPairLen; i++) {
-        (whitespace_selector_one[i] + whitespace_selector_two[i] + whitespace_selector_three[i]) * (1 - is_whitespace[i]) === 0;
+        whitespace_checks[i] <== IsEqual()([(whitespace_selector_one[i] + whitespace_selector_two[i] + whitespace_selector_three[i]) * (1 - is_whitespace[i]), 0]);
     }
+    checks[0] <== MultiAND(maxKVPairLen)(whitespace_checks);
 
     // Verify value does not contain comma, end brace, or quote
     signal value_selector[maxKVPairLen] <== ArraySelector(maxKVPairLen)(value_index, value_index+value_len);
 
+    signal value_checks[maxKVPairLen];
     for (var i = 0; i < maxKVPairLen; i++) {
         var is_comma = IsEqual()([field[i], 44]);
         var is_end_brace = IsEqual()([field[i], 125]);
         var is_quote = IsEqual()([field[i], 34]);
-        value_selector[i] * (is_comma + is_end_brace + is_quote) === 0;
+        value_checks[i] <== IsEqual()([value_selector[i] * (is_comma + is_end_brace + is_quote), 0]);
     }
+    checks[1] <== MultiAND(maxKVPairLen)(value_checks);
+    signal checks_pass <== AND()(checks[0], checks[1]);
+    signal success <== OR()(checks_pass, skip_checks);
+    success === 1;
 }
 
+// Assumes `field_len` is the length of `field` followed by 0-padding, `name_len` is
+// the length of `name` before 0-padding, `value_len` is the length of `value` before 0-padding
+// Takes as input a string `field` corresponding to the field of a JSON name+value pair.
+// It is enforced that `field` has the structure: []name[]':'([]value[]|[]"value"[])(','|'}'),
+// where [] refers to arbitrary whitespace characters, name and value refer to the
+// input fields with the same names, 'x' denotes a specific character, and | denotes
+// that either character or string may be included
+//
+// Assumes `field_len` is the length of `field` followed by 0-padding, `name_len` is
+// the length of `name` before 0-padding, `value_len` is the length of `value` before 0-padding
+//
+// This template exists specifically for the email_verified JWT field, as some providers
+// do not follow the OIDC spec and instead enclose the value of this field in quotes
 template ParseEmailVerifiedField(maxKVPairLen, maxNameLen, maxValueLen) {
     signal input field[maxKVPairLen]; // ASCII
     signal input name[maxNameLen];
@@ -138,15 +214,15 @@ template ParseEmailVerifiedField(maxKVPairLen, maxNameLen, maxValueLen) {
     signal input value_len;
     signal input colon_index; // index of colon within `field`
 
-
-    ParseJWTFieldSharedLogic(maxKVPairLen, maxNameLen, maxValueLen)(field, name, value, field_len, name_len, value_index, value_len, colon_index);
+    ParseJWTFieldSharedLogic(maxKVPairLen, maxNameLen, maxValueLen)(field, name, value, field_len, name_len, value_index, value_len, colon_index, 0); // `skip_checks` is set to 0
 
 
     signal char_before_value <== SelectArrayValue(maxKVPairLen)(field, value_index-1);
     signal before_is_quote      <== IsEqual()([char_before_value, 34]);
     signal before_is_whitespace <== isWhitespace()(char_before_value);
     signal before_is_whitespace_or_quote <== OR()(before_is_quote, before_is_whitespace);
-    // Check the char before is either quote or whitespace, OR that it is the colon
+
+    // Check the char before `value` is either quote or whitespace, OR that it is the colon
     (1 - before_is_whitespace_or_quote)*(value_index-1-colon_index) === 0;
     signal char_after_value <== SelectArrayValue(maxKVPairLen)(field, value_index+value_len);
     signal after_is_quote       <== IsEqual()([char_after_value, 34]);
@@ -180,7 +256,3 @@ template ParseEmailVerifiedField(maxKVPairLen, maxNameLen, maxValueLen) {
         (whitespace_selector_one[i] + whitespace_selector_two[i] + whitespace_selector_three[i]) * (1 - is_whitespace[i]) === 0;
     }
 }
-
-
-
-

--- a/circuit/templates/helpers/misc.circom
+++ b/circuit/templates/helpers/misc.circom
@@ -23,8 +23,8 @@ template isWhitespace() {
 }
 
 // https://github.com/TheFrozenFire/snark-jwt-verify/blob/master/circuits/calculate_total.circom
-// This circuit returns the sum of the inputs.
-// n must be greater than 0.
+// This circuit returns the sum of the inputs in `num`
+// `n` must be greater than 0.
 template CalculateTotal(n) {
     signal input nums[n];
     signal output sum;
@@ -45,6 +45,20 @@ template AssertEqualIfTrue() {
     signal input bool;
 
     (in[0]-in[1]) * bool === 0;
+}
+
+// Given an input `brackets_depth_map`, which must be an output of `BracketsDepthMap` and
+// corresponds to the nested brackets depth of the original JWT, and a `start_index` and `field_len`
+// corresponding to the first index and length of a full field in the JWT, fails if the given field
+// contains any indices inside nested brackets in the original JWT, and succeeds otherwise
+template EnforceNotNested(len) {
+    signal input start_index;
+    signal input field_len;
+    signal input brackets_depth_map[len];
+
+    signal brackets_selector[len] <== ArraySelector(len)(start_index, start_index+field_len);
+    signal is_nested <== EscalarProduct(len)(brackets_depth_map, brackets_selector);
+    is_nested === 0;
 }
 
 // Enforce that if uid name is "email", the email verified field is either true or "true"
@@ -98,9 +112,11 @@ template EmailVerifiedCheck(maxEVNameLen, maxEVValueLen, maxUIDNameLen) {
     }
 }
 
-// Given an array of ascii characters representing a JSON object, output a binary array demarquing 
-//  input = { asdfsdf "asdf" }
-// output = 000000000001111000
+// Given an array of ascii characters representing a JSON object, output a binary array demarquing
+// the spaces in between quotes, so that the indices in between quotes in `in` are given the value
+// `1` in `out`, and are 0 otherwise. Escaped quotes are not considered quotes in this subcircuit
+// input =  { asdfsdf "as\"df" }
+// output = 00000000000111111000
 template StringBodies(len) {
   signal input in[len];
   signal output out[len];
@@ -129,12 +145,10 @@ template StringBodies(len) {
     var is_quote = IsEqual()([in[i], 34]); 
     var prev_is_odd_backslash = adjacent_backslash_parity[i-1];
     quotes[i] <== is_quote * (1 - prev_is_odd_backslash); // 1 iff there is a non-escaped quote at this position
-    quote_parity_1[i] <== quotes[i] * (1 - quote_parity[i-1]); // 1 iff quotes[i] == 1 and quote_parity[i-1] == 0, else 0
-    quote_parity_2[i] <== (1 - quotes[i]) * quote_parity[i-1]; // 1 iff quotes[i] == 0 and quote_party[i-1] == 1, else 0
-    quote_parity[i] <== quote_parity_1[i] + quote_parity_2[i]; // Or of previous two, i.e., XOR(quotes[i], quote_parity[i-1])
+    quote_parity[i] <== XOR()(quotes[i], quote_parity[i-1]);
   }
-  //  input = { asdfsdf "asdf" }
-  // output = 000000000011111000
+  // input =               { asdfsdf "asdf" }
+  // intermediate output = 000000000011111000
   // i.e., still has offset-by-one error
 
   out[0] <== 0;
@@ -144,7 +158,79 @@ template StringBodies(len) {
   }
 }
 
+// Given an array of ASCII characters `arr`, returns an array `brackets` with
+// a 1 in the position of each open bracket `{`, a -1 in the position of each closed bracket `}`
+// and 0 everywhere else.
+//
+// See an example below. The real string is `arr` but we re-display it with "fake" spaces in `align_arr` 
+// to more easily showcase which character in `arr` corresponds to the `-1` in `brackets`.
+// arr:       {he{llo{}world!}}
+// align_arr: {he{llo{ }world! } }
+// brackets:  10010001-1000000-1-1
+//
+// where `arr` is represented by its ASCII encoding, i.e. `{` = 123
+template BracketsMap(len) {
+    signal input arr[len];
+    signal output brackets[len];
 
+    for (var i = 0; i < len; i++) {
+        var is_open_bracket = IsEqual()([arr[i], 123]); // 123 = `{`
+        var is_closed_bracket = IsEqual()([arr[i], 125]); // 125 = '}'
+        brackets[i] <== is_open_bracket + (0-is_closed_bracket);
+    }
+}
+
+// Given an input array `arr` of length `len` containing `1`s corresponding to open
+// brackets `{`, `-1`s corresponding to closed brackets `}`, and 0s everywhere else, outputs an array
+// containing a positive integer in each index between nested brackets which indicates the depth
+// of the brackets nesting at that index, and 0 everywhere else. The outermost open and
+// closed bracket are both ignored. The open and closed brackets are not considered to be inside
+// their bracketed area. It is assumed that the input will contain an equal
+// number of closed and open brackets, and that a closed bracket will not appear while there are no unclosed open brackets
+// The basic algorithm is:
+// 1. Compute an intermediate array where each index is a running sum of all previous indices in the input
+// 2. Subtract 1 from each index in the result of step 1 to get a new array. This corresponds to ignoring the single pair of outermost brackets in the running sum from step 1
+// 3. For each negative value in the result of step 2, change that value to 0
+// 4. For each value greater than 1 compared to the previous value in the result of step 3, decrement that value by 1. This is to fix an off-by-1 error with step 1 in computing nested brackets depth, so that each depth excludes its open bracket. I.e.
+// step 4 in:  001112233332100
+// step 4 out: 000111223332100
+// Example input/output for the entire subcircuit, plus intermediate values
+// To preserve alignment, we use * to represent -1:
+// str:           a{aaa{a{aaa}aa}aaaa}
+// arr:           01000101000*00*0000*
+// prelim_out1:   01111223333222111110   full depth map incorrectly including open brackets inside bracket depth counts
+// prelim_out2:   *000011222211100000*   removes outermost brackets from depth map
+// prelim_out3:   00000112222111000000   replaces negative values with 0s
+// out:           00000011222111000000   correctly represents open brackets as being outside of bracket nesting
+// out: 0000001122 11 0000 0
+template BracketsDepthMap(len) {
+    signal input arr[len];
+    signal output out[len];
+
+    signal prelim_out1[len];
+    signal prelim_out2[len];
+    signal prelim_out3[len];
+    prelim_out1[0] <== arr[0];
+    for (var i = 1; i < len; i++) {
+        prelim_out1[i] <== prelim_out1[i-1] + arr[i];
+    }
+
+    // Subtracting 1 here from every index amounts to ignoring the outermost
+    // open and closed brackets, which is what we want
+    for (var i = 0; i < len; i++) {
+        prelim_out2[i] <== prelim_out1[i]-1;
+    }
+    // Remove all negative numbers from the array and set their indices to 0
+    for (var i = 0; i < len; i++) {
+        var is_neg = LessThan(20)([prelim_out2[i], 0]);
+        prelim_out3[i] <== prelim_out2[i] * (1-is_neg);
+    }
+    // Decrement the positions of open brackets by 1 to remove offset
+    for (var i = 1; i < len; i++) {
+        var is_inc = IsEqual()([prelim_out3[i], prelim_out3[i-1]+1]);
+        out[i] <== prelim_out3[i] - is_inc;
+    }
+}
 
 // Given a base64-encoded array `in`, max length `maxN`, and actual unpadded length `n`, returns
 // the actual length of the decoded string

--- a/circuit/templates/helpers/packing.circom
+++ b/circuit/templates/helpers/packing.circom
@@ -3,6 +3,8 @@ pragma circom 2.1.3;
 include "./arrays.circom";
 
 // Based on `Num2Bits` in circomlib
+// Converts a field element `in` into an array `out` of
+// `n` bits which are all 0 or 1, in big endian order
 template Num2BitsBE(n) {
     signal input in;
     signal output out[n];
@@ -19,7 +21,8 @@ template Num2BitsBE(n) {
     lc1 === in;
 }
 
-// Converts a bit array into a big endian integer
+// Converts a bit array of size `n` into a big endian integer in `out`
+// Assumes `in` contains only 1s and 0s
 // Inspired by Bits2Num in https://github.com/iden3/circomlib/blob/master/circuits/bitify.circom
 template Bits2NumBigEndian(n) { 
     signal input in[n];
@@ -36,7 +39,9 @@ template Bits2NumBigEndian(n) {
 }
 
 
-// Converts byte array `in` into a bit array
+// Converts byte array `in` into a bit array. All values in `in` are
+// assumed to be one byte each, i.e. between 0 and 255 inclusive.
+// These bytes are also assumed to be in big endian order
 template BytesToBits(inputLen) {
     signal input in[inputLen];
     var byte_len = 8;
@@ -55,6 +60,7 @@ template BytesToBits(inputLen) {
 
 // Converts bit array 'in' into an array of field elements of size `bitsPerFieldElem` each
 // Example: with inputLen=11, bitsPerFieldElem=4, [0,0,0,0, 0,0,0,1, 0,1,1,] ==> [0, 1, 6]
+// Assumes all values in `in` are 0 or 1
 template BitsToFieldElems(inputLen, bitsPerFieldElem) {
     signal input in[inputLen];
     var num_elems = inputLen%bitsPerFieldElem == 0 ? inputLen \ bitsPerFieldElem : (inputLen\bitsPerFieldElem) + 1; // '\' is the quotient operation - we add 1 if there are extra bits past the full bytes

--- a/circuit/templates/tests/arrays/array_selector_complex_test.circom
+++ b/circuit/templates/tests/arrays/array_selector_complex_test.circom
@@ -8,6 +8,10 @@ template array_selector_complex_test(len) {
     signal input expected_output[len];
     
     signal out[len] <== ArraySelectorComplex(len)(start_index, end_index);
+    for (var i =0; i < len; i++) {
+        log(out[i]);
+        log(expected_output[i]);
+    }
     out === expected_output;
 }
 

--- a/circuit/templates/tests/arrays/elementwise_mul_test.circom
+++ b/circuit/templates/tests/arrays/elementwise_mul_test.circom
@@ -1,0 +1,18 @@
+pragma circom 2.1.3;
+
+include "helpers/arrays.circom";
+
+template elementwise_mul_test(len) {
+    signal input left[len];
+    signal input right[len];
+    signal input expected_out[len];
+
+    signal out[len] <== ElementwiseMul(len)(left, right);
+    for (var i = 0; i < len; i++) {
+        out[i] === expected_out[i];
+    }
+}
+
+component main = elementwise_mul_test(
+   4
+);

--- a/circuit/templates/tests/arrays/invert_binary_array_test.circom
+++ b/circuit/templates/tests/arrays/invert_binary_array_test.circom
@@ -1,0 +1,17 @@
+pragma circom 2.1.3;
+
+include "helpers/arrays.circom";
+
+template invert_binary_array_test(len) {
+    signal input in[len];
+    signal input expected_out[len];
+    
+    signal out[len] <== InvertBinaryArray(len)(in);
+    for (var i = 0; i < len; i++) {
+        out[i] === expected_out[i];
+    }
+}
+
+component main = invert_binary_array_test(
+   4
+);

--- a/circuit/templates/tests/misc/brackets_depth_map_test.circom
+++ b/circuit/templates/tests/misc/brackets_depth_map_test.circom
@@ -1,0 +1,25 @@
+pragma circom 2.1.3;
+
+include "helpers/misc.circom";
+
+template brackets_depth_map_test() {
+    var len = 15;
+    signal input in[len];
+    signal input brackets[len];
+    component brackets_depth_map = BracketsDepthMap(len);
+    brackets_depth_map.arr <== in;
+    for (var i = 0; i < len; i++) {
+        log("out ", i, ": ", brackets_depth_map.out[i]);
+    }
+    for (var i = 0; i < len; i++) {
+        log("in ", i, ": ", in[i]);
+    }
+    for (var i = 0; i < len; i++) {
+        log("expected result ", i, ": ", brackets[i]);
+    }
+    for (var i = 0; i < len; i++) {
+        brackets[i] === brackets_depth_map.out[i];
+    }
+}
+
+component main = brackets_depth_map_test();

--- a/circuit/templates/tests/misc/brackets_map_test.circom
+++ b/circuit/templates/tests/misc/brackets_map_test.circom
@@ -1,0 +1,16 @@
+pragma circom 2.1.3;
+
+include "helpers/misc.circom";
+
+template brackets_map_test() {
+    var len = 13;
+    signal input in[len];
+    signal input brackets[len];
+    component brackets_map = BracketsMap(len);
+    brackets_map.arr <== in;
+    for (var i = 0; i < len; i++) {
+        brackets[i] === brackets_map.brackets[i];
+    }
+}
+
+component main = brackets_map_test();

--- a/circuit/tools/input_gen.py
+++ b/circuit/tools/input_gen.py
@@ -223,6 +223,7 @@ override_aud_value_value = pad_string("", maxAudValueLen)
 private_aud_value_len_value = aud_value_len_value
 override_aud_value_len_value = '"' + "0" + '"'
 use_aud_override_value = '"' + "0" + '"'
+skip_aud_checks_value = '"' + "0" + '"'
 
 maxIatKVPairLen = 50
 maxIatNameLen = 10
@@ -445,7 +446,7 @@ jwt_payload_string = unsigned_b64_jwt_string_sha_padded[unsigned_b64_jwt_string_
 payload_value = pad_string(jwt_payload_string, jwt_max_payload_len)
 
 # Compute RSA signature over the full unsigned JWT
-with open(f"./test_rsa_privkey.pem", 'rb') as f:
+with open(f"./tools/test_rsa_privkey.pem", 'rb') as f:
     privkey_str = f.read()
     f.close()
 keyPair = Crypto.PublicKey.RSA.import_key(privkey_str)
@@ -554,7 +555,8 @@ json_dict = {
     "\"extra_field_len\"": extra_field_len_value,
     "\"extra_index\"": extra_index_value,
     "\"jwt_payload_without_sha_padding\"": jwt_payload_string_no_padding_value,
-    "\"use_extra_field\"": use_extra_field_value
+    "\"use_extra_field\"": use_extra_field_value,
+    "\"skip_aud_checks\"": skip_aud_checks_value
 }
 inputs_dot_json = format_output(json_dict)
 


### PR DESCRIPTION
# What is the change being pushed?

**Federated `aud`-less accounts:**  
Relaxes the keyless relation to allow for an empty `aud` in the [identity commitment (IDC)](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-61.md#public-keys) from which a keyless account's address is derived.

This allows developers (e.g., via the Aptos SDK) to create [Federated keyless](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-96.md) accounts that are bound not to an application but to all applications of a "tenant" within a federated provider like Auth0.

This feature is more comprehensively described in [AIP-108](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-108.md).

**Nested JSON parsing:**  
With the introduction of Federated keyless accounts, it is theoretically possible for federated providers like AWS Cognito or Auth0 to give more control to developers over the contents of issued JWTs. In particular, a developer may be able to embed a `sub` or `aud` field at a "deeper" level in the JSON, potentially tricking the parsing in the old circuit code.

This security feature ensures the circuit cannot be tricked and always parses sensitive fields like `iss`, `sub`, `aud`, `email`, etc., at depth zero.

<!--
 Describe **what** the change is. e.g.,:
  - fixing a soundness bug in the the IsLessThan() template
  - adding a new test for IsLessThan() to ensure that 3 < 3 cannot be satisfied
  - adding an new `/vk` endpoint to the prover service
-->

## Why are you pushing this change?

### Federated `aud`-less accounts

A developer may deploy many keyless dapps, each with its own `aud`, but all hosted on the same (say) Auth0 tenant.

However, this developer may want to derive the same keyless account for a user across all of its dapps, which would not be possible without this feature sine the `aud` differs.

### Nested JSON

A potentially-malicious or clueless developer could insert a nested `sub` (or `aud`) field in the JWT it issues via its federated OIDC provider like AWS Cognito.

If such a nested field is adversarially-controlled it could be used to access other user's keyless accounts.

## How is this implemented?

The federated `aud`less feature is documented in [AIP-108](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-108.md).

The nested JSON fix augments the circuit logic to detect the "depth" of a parsed field (like `sub`) in a heavily-optimized way. We hope to describe this later, in depth, in a blog post.

# Type of Change

**Circuit change?**

- [x] New circuit feature
- [ ] Circuit correctness fix
- [x] Circuit soundness fix
- [x] Circuit test cases
- [ ] Circuit benchmarks

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all keyless stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
