### PR TITLE
add pre-commit hook to try and compile circom if there are changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ onchain_vk.json
 onchain_vk_2.json
 prover_request_payload.json
 __pycache__
+
+*.r1cs

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -2,7 +2,13 @@
 
 set -e
 set -x
-./circuit/tools/install-deps.sh
-export RESOURCES_DIR="$HOME/.local/share/aptos-prover-service"
-python3 ./scripts/prepare_setups.py
-./prover/scripts/dev_setup.sh
+#./circuit/tools/install-deps.sh
+#export RESOURCES_DIR="$HOME/.local/share/aptos-prover-service"
+#python3 ./scripts/prepare_setups.py
+#./prover/scripts/dev_setup.sh
+
+
+# Install pre-commit hook
+cp git-hooks/compile-circom-if-needed-pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+echo "Installed pre-commit hook for circom compilation successfully!"

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -2,10 +2,10 @@
 
 set -e
 set -x
-#./circuit/tools/install-deps.sh
-#export RESOURCES_DIR="$HOME/.local/share/aptos-prover-service"
-#python3 ./scripts/prepare_setups.py
-#./prover/scripts/dev_setup.sh
+./circuit/tools/install-deps.sh
+export RESOURCES_DIR="$HOME/.local/share/aptos-prover-service"
+python3 ./scripts/prepare_setups.py
+./prover/scripts/dev_setup.sh
 
 
 # Install pre-commit hook

--- a/git-hooks/compile-circom-if-needed-pre-commit
+++ b/git-hooks/compile-circom-if-needed-pre-commit
@@ -4,7 +4,7 @@
 if git diff --cached --name-only | grep -q '^circuit/templates/.*\.circom$'; then
     echo "Detected changes in *.circom files!"
     echo
-    echo "Running circom compilation. This will take ~20 seconds..."
+    echo "Running circom compilation. This will take ~45 seconds..."
 
     # Move into the circuit/templates directory
     pushd circuit/templates > /dev/null

--- a/git-hooks/compile-circom-if-needed-pre-commit
+++ b/git-hooks/compile-circom-if-needed-pre-commit
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Check if any .circom files in 'circuit/templates' changed
+if git diff --cached --name-only | grep -q '^circuit/templates/.*\.circom$'; then
+    echo "Detected changes in *.circom files!"
+    echo
+    echo "Running circom compilation. This will take ~20 seconds..."
+
+    # Move into the circuit/templates directory
+    pushd circuit/templates > /dev/null
+
+    # Run your circom command
+    circom -l "$(npm root -g)" main.circom --r1cs
+
+    # Check if circom command succeeded
+    if [ $? -ne 0 ]; then
+        echo "Error: circom compilation failed. Commit aborted."
+        popd > /dev/null
+        exit 1
+    fi
+
+    echo "circom compilation succeeded."
+    popd > /dev/null
+fi
+
+exit 0


### PR DESCRIPTION
# What is the change being pushed?

Adding a pre-commit hook to try and compile the circom code if there were changes to it.

## Why are you pushing this change?

Want to do some maintenance on the circuit code & want to ensure none of my commits break the compilation.

In general, good to detect this earlier during commit time than during CI/CD.

## How is this implemented?

Added a `git-hooks` directory that contains the hook and updated the `dev_setup.sh` script to install it in `.git/hooks/pre-commit`.

# Type of change

<!-- 
Select one or more for each category, as applicable.
Delete the category, if not applicable.
Or, introduce your own, if needed.
-->

**Other?**

 - [x] Testing

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all keyless stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
