### PR TITLE
Fix typos in comments and variable names

### DIFF
--- a/circuit/templates/helpers/arrays.circom
+++ b/circuit/templates/helpers/arrays.circom
@@ -363,7 +363,7 @@ template ASCIIDigitsToField(maxLen) {
 
     signal success;
     var index_eq_sum = 0;
-    // `s` is initally set to 1 and is 0 after len == i
+    // `s` is initially set to 1 and is 0 after len == i
     var s = 1; 
 
     accumulators[0] <== digits[0]-48;

--- a/circuit/templates/helpers/misc.circom
+++ b/circuit/templates/helpers/misc.circom
@@ -237,7 +237,7 @@ template BracketsDepthMap(len) {
 template Base64DecodedLength(maxN) {
     var max_q = (3 * maxN) \ 4;
     //signal input in[maxN];
-    signal input n; // actual lenght
+    signal input n; // actual length
     signal output decoded_len;
     signal q <-- 3*n \ 4;
     signal r <-- 3*n % 4;

--- a/rust-rapidsnark/rapidsnark/src/logger.hpp
+++ b/rust-rapidsnark/rapidsnark/src/logger.hpp
@@ -117,7 +117,7 @@ public:
     void debug(std::ostringstream& stream) throw();
 
     // Error and Alarm log must be always enable
-    // Hence, there is no interfce to control error and alarm logs
+    // Hence, there is no interface to control error and alarm logs
 
     // Interfaces to control log levels
     void updateLogLevel(LogLevel logLevel);


### PR DESCRIPTION
This PR fixes several typos across multiple files:

- circuit/templates/helpers/arrays.circom: Fix typo "initally" -> "initially" in comment
- circuit/templates/helpers/misc.circom: Fix typo "lenght" -> "length" in comment
- rust-rapidsnark/rapidsnark/src/logger.hpp: Fix typo "interfce" -> "interface" in comment

These changes are purely cosmetic and do not affect functionality.