### PR TITLE
Fix CI "run cargo test on macos"

### DIFF
--- a/circuit/templates/mainTemplate.circom
+++ b/circuit/templates/mainTemplate.circom
@@ -148,13 +148,11 @@ template identity(
     skip_aud_checks_and_use_aud_override === 0;
 
     skip_aud_checks * (skip_aud_checks-1) === 0; // Ensure equal to 0 or 1
-    var s = use_aud_override;
-    s * (s-1) === 0; // Ensure s = 0 or s = 1
     for (var i = 0; i < maxAudValueLen; i++) {
-        aud_value[i] <== (override_aud_value[i]-private_aud_value[i]) * s + private_aud_value[i];
+        aud_value[i] <== (override_aud_value[i]-private_aud_value[i]) * use_aud_override + private_aud_value[i];
     }
     signal aud_value_len;
-    aud_value_len <== (override_aud_value_len-private_aud_value_len) * s + private_aud_value_len;
+    aud_value_len <== (override_aud_value_len-private_aud_value_len) * use_aud_override + private_aud_value_len;
 
     ParseJWTFieldWithQuotedValue(maxAudKVPairLen, maxAudNameLen, maxAudValueLen)(aud_field, aud_name, aud_value, aud_field_string_bodies, aud_field_len, aud_name_len, aud_value_index, aud_value_len, aud_colon_index, skip_aud_checks);
 

--- a/circuit/templates/mainTemplate.circom
+++ b/circuit/templates/mainTemplate.circom
@@ -148,11 +148,13 @@ template identity(
     skip_aud_checks_and_use_aud_override === 0;
 
     skip_aud_checks * (skip_aud_checks-1) === 0; // Ensure equal to 0 or 1
+    var s = use_aud_override;
+    s * (s-1) === 0; // Ensure s = 0 or s = 1
     for (var i = 0; i < maxAudValueLen; i++) {
-        aud_value[i] <== (override_aud_value[i]-private_aud_value[i]) * use_aud_override + private_aud_value[i];
+        aud_value[i] <== (override_aud_value[i]-private_aud_value[i]) * s + private_aud_value[i];
     }
     signal aud_value_len;
-    aud_value_len <== (override_aud_value_len-private_aud_value_len) * use_aud_override + private_aud_value_len;
+    aud_value_len <== (override_aud_value_len-private_aud_value_len) * s + private_aud_value_len;
 
     ParseJWTFieldWithQuotedValue(maxAudKVPairLen, maxAudNameLen, maxAudValueLen)(aud_field, aud_name, aud_value, aud_field_string_bodies, aud_field_len, aud_name_len, aud_value_index, aud_value_len, aud_colon_index, skip_aud_checks);
 

--- a/scripts/python/setups/testing_setup.py
+++ b/scripts/python/setups/testing_setup.py
@@ -61,9 +61,8 @@ class TestingSetup(setups.Setup):
 
     def run_setup(self):
         eprint("Starting setup now: " + datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
-        utils.run_shell_command(f'. ~/.nvm/nvm.sh; node -e "console.log(v8.getHeapStatistics().heap_size_limit / 1024 / 1024)"')
         start_time = time.time()
-        utils.run_shell_command(f'. ~/.nvm/nvm.sh; NODE_OPTIONS=--max-old-space-size=8192 snarkjs groth16 setup main_c.r1cs {PTAU_PATH} prover_key.zkey')
+        utils.run_shell_command(f'. ~/.nvm/nvm.sh; NODE_OPTIONS=--max-old-space-size=8192 snarkjs groth16 setup main_c.r1cs {PTAU_PATH} prover_key.zkey')  # default heap size was ~2000MB
         eprint("Running setup took %s seconds" % (time.time() - start_time))
         eprint("Exporting verification key...")
         utils.run_shell_command(f'. ~/.nvm/nvm.sh; snarkjs zkey export verificationkey prover_key.zkey verification_key.json')

--- a/scripts/python/setups/testing_setup.py
+++ b/scripts/python/setups/testing_setup.py
@@ -64,7 +64,7 @@ class TestingSetup(setups.Setup):
         print('ZJDB')
         utils.run_shell_command(f'. ~/.nvm/nvm.sh; node -e "console.log(v8.getHeapStatistics().heap_size_limit / 1024 / 1024)"')
         start_time = time.time()
-        utils.run_shell_command(f'. ~/.nvm/nvm.sh; snarkjs groth16 setup main_c.r1cs {PTAU_PATH} prover_key.zkey')
+        utils.run_shell_command(f'. ~/.nvm/nvm.sh; NODE_OPTIONS=--max-old-space-size=8192 snarkjs groth16 setup main_c.r1cs {PTAU_PATH} prover_key.zkey')
         eprint("Running setup took %s seconds" % (time.time() - start_time))
         eprint("Exporting verification key...")
         utils.run_shell_command(f'snarkjs zkey export verificationkey prover_key.zkey verification_key.json')

--- a/scripts/python/setups/testing_setup.py
+++ b/scripts/python/setups/testing_setup.py
@@ -61,6 +61,8 @@ class TestingSetup(setups.Setup):
 
     def run_setup(self):
         eprint("Starting setup now: " + datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+        print('ZJDB')
+        utils.run_shell_command(f'. ~/.nvm/nvm.sh; node -e "console.log(v8.getHeapStatistics().heap_size_limit / 1024 / 1024)"')
         start_time = time.time()
         utils.run_shell_command(f'. ~/.nvm/nvm.sh; snarkjs groth16 setup main_c.r1cs {PTAU_PATH} prover_key.zkey')
         eprint("Running setup took %s seconds" % (time.time() - start_time))

--- a/scripts/python/setups/testing_setup.py
+++ b/scripts/python/setups/testing_setup.py
@@ -61,13 +61,12 @@ class TestingSetup(setups.Setup):
 
     def run_setup(self):
         eprint("Starting setup now: " + datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
-        print('ZJDB')
         utils.run_shell_command(f'. ~/.nvm/nvm.sh; node -e "console.log(v8.getHeapStatistics().heap_size_limit / 1024 / 1024)"')
         start_time = time.time()
         utils.run_shell_command(f'. ~/.nvm/nvm.sh; NODE_OPTIONS=--max-old-space-size=8192 snarkjs groth16 setup main_c.r1cs {PTAU_PATH} prover_key.zkey')
         eprint("Running setup took %s seconds" % (time.time() - start_time))
         eprint("Exporting verification key...")
-        utils.run_shell_command(f'snarkjs zkey export verificationkey prover_key.zkey verification_key.json')
+        utils.run_shell_command(f'. ~/.nvm/nvm.sh; snarkjs zkey export verificationkey prover_key.zkey verification_key.json')
 
 
     def compile_c_witness_gen_binaries(self):


### PR DESCRIPTION
The "run cargo test on macos" check will [fail with OOM for new circuit PRs](https://github.com/aptos-labs/keyless-zk-proofs/actions/runs/15171680407/job/42664513206?pr=49#step:4:778) due to a bad default configuration.

Configure it correctly.
