### PR TITLE
[Cleanups] Small cleanups to README and Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,19 +5,12 @@ members = ["circuit", "keyless-common", "prover-service", "vk-diff", "release-he
 
 [workspace.package]
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
-name = "prover-service"
-version = "0.1.0"
 edition = "2021"
-rust-version = "1.78.0"
-publish = false
 homepage = "https://aptoslabs.com"
 license = "GPL3"
-repository = "https://github.com/aptos-labs/prover-service"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[profile.release]
-debug = true
-overflow-checks = true
+publish = false
+repository = "https://github.com/aptos-labs/keyless-zk-proofs"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
 anyhow = "1.0.79"
@@ -97,6 +90,10 @@ ureq = { version = "1.5.4", features = [
 ], default-features = false }
 url = { version = "2.5.4" }
 uuid = { version = "1.17.0", features = ["v4"] }
+
+[profile.release]
+debug = true
+overflow-checks = true
 
 [patch.crates-io]
 merlin = { git = "https://github.com/aptos-labs/merlin" }

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 This repo contains:
 1. The `circom` implementation of the Aptos Keyless ZK relation from AIP-61 in `circuit/templates/`.
-2. An implementation of a ZK proving service in `prover-service/`. Its
-   [README](./prover-service/README.md) contains instructions for building
-   and running tests.
+2. An implementation of a ZK proving service in `prover-service/`.
 3. A circom unit testing framework in `circuit/`. Its
    [README](./circuit/README.md) contains instructions for running the
    circuit unit tests.
@@ -59,23 +57,3 @@ In a new terminal, make a request to the prover and expect it to finish normally
 ```bash
 curl -X POST -H "Content-Type: application/json" -d @/tmp/prover_request_payload.json http://localhost:8083/v0/prove
 ```
-
-## TODOs
-
-### Prover service
-
- - [x] Why is the description of `keyless-common/` set to "Aptos Keyless circuit tests" in its `Cargo.toml`?
-   - Changed description to "Shared code that is used both by the prover service and circuit unit tests."
- - [x] The `Cargo.toml` description of `circuit/` also seem inappropriate
-   - Changed description to "The Aptos Keyless circuit (circom) and unit tests (rust)."
- - [ ] Redundant `OnChainGroth16VerificationKey` struct
- - [ ] Move some shared `prover` and `vk-diff` code to `keyless-common`
-
-### Circuit
-
- - [ ] Remove public inputs hash and do commit-and-prove
- - [ ] Pedersen-based keyless addresses and avoid Poseidon hashing, except for Fiat-Shamir maybe
- - [ ] The circuit is in the `circuit` directory, but its Cargo.toml sets
-       the crate name to be `aptos-keyless-circuit`. Might be less
-       confusing to have the directory name agree with the crate name?
-

--- a/prover-service/Cargo.toml
+++ b/prover-service/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "prover-service"
+description = "Aptos Keyless Prover Service"
 version = "0.1.0"
-edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[profile.release]
-debug = true
-overflow-checks = true
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
@@ -67,9 +71,3 @@ tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
-
-[patch.crates-io]
-merlin = { git = "https://github.com/aptos-labs/merlin" }
-x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }
-
-

--- a/release-helper/src/main.rs
+++ b/release-helper/src/main.rs
@@ -4,7 +4,7 @@ use aptos_keyless_common::groth16_vk::{
 use clap::{Parser, Subcommand};
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Parser)]
 #[clap(name = "release-helper")]
@@ -86,17 +86,17 @@ fn main() {
 }
 
 fn generate_governance_proposal(
-    repo_path: &PathBuf,
+    repo_path: &Path,
     circuit_release_tag: &str,
     tw_key_id: &str,
     vk_path: &PathBuf,
     twpk_path: &PathBuf,
 ) {
-    new_release_yaml(&repo_path, circuit_release_tag, tw_key_id);
-    generate_proposal_script(&repo_path, vk_path, twpk_path);
+    new_release_yaml(repo_path, circuit_release_tag, tw_key_id);
+    generate_proposal_script(repo_path, vk_path, twpk_path);
 }
 
-fn new_release_yaml(aptos_core_path: &PathBuf, circuit_release_tag: &str, tw_key_id: &str) {
+fn new_release_yaml(aptos_core_path: &Path, circuit_release_tag: &str, tw_key_id: &str) {
     let target_path =
         aptos_core_path.join("aptos-move/aptos-release-builder/data/keyless-config-update.yaml");
     println!("Writing to {target_path:?}.");
@@ -119,7 +119,7 @@ proposals:
     file.write_all(release_yaml_content.as_bytes()).unwrap();
 }
 
-fn generate_proposal_script(repo_path: &PathBuf, vk_path: &PathBuf, twpk_path: &PathBuf) {
+fn generate_proposal_script(repo_path: &Path, vk_path: &PathBuf, twpk_path: &PathBuf) {
     let script_content =
         generate_script_content(ProposalExecutionMode::ProposalID, vk_path, twpk_path);
     let target_path = repo_path
@@ -159,11 +159,11 @@ fn generate_script_content(
     twpk_path: &PathBuf,
 ) -> String {
     // Read the verification key file
-    let local_vk_json = fs::read_to_string(&vk_path).unwrap();
+    let local_vk_json = fs::read_to_string(vk_path).unwrap();
     let local_vk: SnarkJsGroth16VerificationKey = serde_json::from_str(&local_vk_json).unwrap();
     let vk = OnChainGroth16VerificationKey::try_from(local_vk).unwrap();
     // Read the training wheel public key file
-    let twpk_repr = fs::read_to_string(&twpk_path).unwrap();
+    let twpk_repr = fs::read_to_string(twpk_path).unwrap();
 
     let (main_param, framework_signer_expression) = match mode {
         ProposalExecutionMode::RootSigner => (

--- a/rust-rapidsnark/Cargo.toml
+++ b/rust-rapidsnark/Cargo.toml
@@ -1,14 +1,19 @@
 [package]
 name = "rust-rapidsnark"
+description = "Rust bindings for RapidSnark"
 version = "0.1.0"
-edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
-thiserror = { workspace = true } 
-
-[build]
+thiserror = { workspace = true }
 
 [build-dependencies]
 bindgen = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.89.0"
+
+components = ["cargo", "clippy", "rustc", "rustfmt", "rust-docs", "rust-std"]

--- a/scripts/task.sh
+++ b/scripts/task.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 SCRIPT_DIR=$(dirname "$0")
 


### PR DESCRIPTION
# What is the change being pushed?
This PR makes several small cleanups to the repo, e.g.:
- README cleanups
- Specifying the rust toolchain version and minimum version to build the project
- Cargo.toml cleanups
- Fixing a few clippy lints.

Outside of these, nothing should logically change 😄 

# Testing Plan
Existing test infrastructure.
