### PR TITLE
[CI/CD] Fix failing CI/CD tests.

### DIFF
--- a/scripts/python/setups/testing_setup.py
+++ b/scripts/python/setups/testing_setup.py
@@ -89,7 +89,7 @@ class TestingSetup(setups.Setup):
             shutil.move("main_c_cpp/main_c.dat", self.path())
 
 
-    def c_witness_gen_from_scratch():
+    def c_witness_gen_from_scratch(self):
         eprint("Setup doesn't contain c witness gen binaries, and you are on x86-64. Going to compile them now.")
         self.compile_circuit()
         self.compile_c_witness_gen_binaries()


### PR DESCRIPTION
# What is the change being pushed?
This PR fixes the failing `cargo test` job on `main`. Not sure why we haven't hit it before yet 🤔 Without the fix, the job reports [this](https://github.com/aptos-labs/keyless-zk-proofs/actions/runs/18909906915/job/53982688518?pr=76).

# Testing Plan
Existing test infrastructure (i.e., CI/CD).