### PR TITLE
[Prover Service] Add `/about` endpoint, and rename `/meta` -> `/config`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-build-info"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?rev=0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627#0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627"
+dependencies = [
+ "shadow-rs",
+]
+
+[[package]]
 name = "aptos-crypto"
 version = "0.0.3"
 source = "git+https://github.com/aptos-labs/aptos-core?branch=main#b163f034c0e1e01b59cef44694da9dbccb4d5b63"
@@ -1118,9 +1126,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "cexpr"
@@ -1276,6 +1290,32 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_fn"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1847,6 +1887,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
 name = "fixed"
 version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,6 +2122,19 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "git2"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -2726,6 +2785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_debug"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,6 +2822,16 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2811,6 +2886,18 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.14.2+1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2885,6 +2972,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3402,6 +3501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -4151,9 +4259,12 @@ name = "prover-service"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-build-info",
  "aptos-crypto",
  "aptos-crypto-derive 0.0.3 (git+https://github.com/aptos-labs/aptos-core?rev=0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627)",
+ "aptos-infallible 0.1.0 (git+https://github.com/aptos-labs/aptos-core?rev=0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627)",
  "aptos-keyless-common",
+ "aptos-logger",
  "aptos-types",
  "ark-bn254",
  "ark-ff",
@@ -4924,6 +5035,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-rs"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0ea0c68418544f725eba5401a5b965a2263254c92458d04aeae74e9d88ff4e"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time",
+ "tzdb",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5290,7 +5414,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5694,6 +5820,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c420cf38925a5a6a3dc56e1c8f56f17a5b7755edd5adeb7cdab8b847e1fbe2af"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+ "utcnow",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d69ad05cd8412d9f6e7df6ac91e50ea557687cc1b734339cb6742e547704663"
+dependencies = [
+ "tz-rs",
+]
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5725,6 +5881,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -5781,6 +5943,23 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utcnow"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1b903f7711bad0f9c1716c1497bf3db4289c53a2985ba42ac2f2e04047bd9"
+dependencies = [
+ "const_fn",
+ "errno",
+ "js-sys",
+ "libc",
+ "rustix",
+ "rustversion",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+ "winapi",
+]
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ rust-version = "1.85.0"
 
 [workspace.dependencies]
 anyhow = "1.0.79"
+aptos-build-info = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
 aptos-crypto = { git = "https://github.com/aptos-labs/aptos-core", branch = "main" } # TODO: pin to a specific rev
 aptos-crypto-derive = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
+aptos-infallible = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
 aptos-keyless-common = { path = "keyless-common" }
 aptos-logger = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
 aptos-types = { git = "https://github.com/aptos-labs/aptos-core", branch = "main" } # TODO: pin to a specific rev

--- a/prover-service/Cargo.toml
+++ b/prover-service/Cargo.toml
@@ -14,9 +14,12 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-build-info = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }
+aptos-infallible = { workspace = true }
 aptos-keyless-common = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-types = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ff = { workspace = true }

--- a/prover-service/src/deployment_information.rs
+++ b/prover-service/src/deployment_information.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_build_info::build_information;
+use aptos_infallible::Mutex;
+use std::{collections::BTreeMap, sync::Arc};
+
+/// A simple struct to hold deployment information as key-value pairs
+#[derive(Clone, Debug)]
+pub struct DeploymentInformation {
+    deployment_information_map: Arc<Mutex<BTreeMap<String, String>>>,
+}
+
+impl DeploymentInformation {
+    pub fn new() -> Self {
+        // Collect the build information and initialize the map
+        let build_information = build_information!();
+        let deployment_information_map = Arc::new(Mutex::new(build_information));
+
+        Self {
+            deployment_information_map,
+        }
+    }
+
+    /// Adds a new key-value pair to the deployment information map
+    pub fn extend_deployment_information(&mut self, key: String, value: String) {
+        self.deployment_information_map.lock().insert(key, value);
+    }
+
+    /// Returns a copy of the deployment information map
+    pub fn get_deployment_information(&self) -> BTreeMap<String, String> {
+        self.deployment_information_map.lock().clone()
+    }
+}
+
+impl Default for DeploymentInformation {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/prover-service/src/handlers.rs
+++ b/prover-service/src/handlers.rs
@@ -24,7 +24,22 @@ use aptos_keyless_common::logging::HasLoggableError;
 use maplit2::hashmap;
 use serde::Deserialize;
 use std::{sync::Arc, time::Instant};
+use aptos_logger::error;
 use uuid::Uuid;
+
+/// Returns deployment information as a JSON string
+pub async fn about_handler(State(state): State<Arc<ProverServiceState>>) -> (StatusCode, String) {
+    let deployment_information = state.deployment_information().get_deployment_information();
+    match serde_json::to_string_pretty(&deployment_information) {
+        Ok(deployment_information) => (StatusCode::OK, deployment_information),
+        Err(error) => {
+            // Log and return the error
+            let error_string = format!("Failed to serialize deployment information to JSON: {}", error);
+            error!("{}", error_string);
+            (StatusCode::INTERNAL_SERVER_ERROR, error_string)
+        },
+    }
+}
 
 pub async fn prove_handler(
     State(state): State<Arc<ProverServiceState>>,

--- a/prover-service/src/lib.rs
+++ b/prover-service/src/lib.rs
@@ -4,6 +4,7 @@ extern crate core;
 
 pub mod api;
 pub mod config;
+pub mod deployment_information;
 pub mod error;
 pub mod groth16_vk;
 pub mod handlers;

--- a/prover-service/src/lib.rs
+++ b/prover-service/src/lib.rs
@@ -17,6 +17,7 @@ pub mod prover_key;
 pub mod proving;
 pub mod state;
 pub mod training_wheels;
+pub mod utils;
 pub mod witness_gen;
 
 #[cfg(test)]

--- a/prover-service/src/state.rs
+++ b/prover-service/src/state.rs
@@ -10,6 +10,7 @@ use crate::config::{ProverServiceConfig, CONFIG};
 use crate::groth16_vk::OnChainGroth16VerificationKey;
 use crate::prover_key::TrainingWheelsKeyPair;
 use tokio::sync::Mutex;
+use crate::deployment_information::DeploymentInformation;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProverServiceSecrets {
@@ -20,13 +21,14 @@ pub struct ProverServiceSecrets {
 pub struct ProverServiceState {
     pub config: ProverServiceConfig,
     pub circuit_metadata: CircuitConfig,
+    pub deployment_information : DeploymentInformation,
     pub groth16_vk: OnChainGroth16VerificationKey,
     pub tw_keys: TrainingWheelsKeyPair,
     pub full_prover: Mutex<FullProver>,
 }
 
 impl ProverServiceState {
-    pub fn init() -> Self {
+    pub fn init(deployment_information: DeploymentInformation) -> Self {
         let ProverServiceSecrets {
             private_key_0: private_key,
         } = Figment::new()
@@ -37,13 +39,20 @@ impl ProverServiceState {
         ProverServiceState {
             config: CONFIG.clone(),
             circuit_metadata: CONFIG.load_circuit_params(),
+            deployment_information,
             groth16_vk: CONFIG.load_vk(),
             tw_keys: TrainingWheelsKeyPair::from_sk(private_key),
             full_prover: Mutex::new(FullProver::new(&CONFIG.zkey_path()).unwrap()),
         }
     }
 
+    /// Returns a reference to the circuit configuration
     pub fn circuit_config(&self) -> &CircuitConfig {
         &self.circuit_metadata
+    }
+
+    /// Returns a reference to the deployment information
+    pub fn deployment_information(&self) -> &DeploymentInformation {
+        &self.deployment_information
     }
 }

--- a/prover-service/src/state.rs
+++ b/prover-service/src/state.rs
@@ -7,10 +7,10 @@ use rust_rapidsnark::FullProver;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{ProverServiceConfig, CONFIG};
+use crate::deployment_information::DeploymentInformation;
 use crate::groth16_vk::OnChainGroth16VerificationKey;
 use crate::prover_key::TrainingWheelsKeyPair;
 use tokio::sync::Mutex;
-use crate::deployment_information::DeploymentInformation;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProverServiceSecrets {
@@ -21,7 +21,7 @@ pub struct ProverServiceSecrets {
 pub struct ProverServiceState {
     pub config: ProverServiceConfig,
     pub circuit_metadata: CircuitConfig,
-    pub deployment_information : DeploymentInformation,
+    pub deployment_information: DeploymentInformation,
     pub groth16_vk: OnChainGroth16VerificationKey,
     pub tw_keys: TrainingWheelsKeyPair,
     pub full_prover: Mutex<FullProver>,

--- a/prover-service/src/tests/common/mod.rs
+++ b/prover-service/src/tests/common/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 
 use self::types::{DefaultTestJWKKeyPair, TestJWKKeyPair, WithNonce};
+use crate::deployment_information::DeploymentInformation;
 use crate::load_vk::prepared_vk;
 use crate::tests::common::types::ProofTestCase;
 use crate::training_wheels;
@@ -32,7 +33,6 @@ use rust_rapidsnark::FullProver;
 use serde::Serialize;
 use std::{marker::PhantomData, str::FromStr, sync::Arc};
 use tokio::sync::Mutex;
-use crate::deployment_information::DeploymentInformation;
 
 pub mod types;
 

--- a/prover-service/src/tests/common/mod.rs
+++ b/prover-service/src/tests/common/mod.rs
@@ -32,6 +32,7 @@ use rust_rapidsnark::FullProver;
 use serde::Serialize;
 use std::{marker::PhantomData, str::FromStr, sync::Arc};
 use tokio::sync::Mutex;
+use crate::deployment_information::DeploymentInformation;
 
 pub mod types;
 
@@ -113,6 +114,7 @@ pub async fn convert_prove_and_verify(
     let state = ProverServiceState {
         config: testcase.prover_service_config.clone(),
         circuit_metadata: testcase.prover_service_config.load_circuit_params(),
+        deployment_information: DeploymentInformation::new(),
         groth16_vk: testcase.prover_service_config.load_vk(),
         tw_keys: TrainingWheelsKeyPair::from_sk(tw_sk_default),
         full_prover: Mutex::new(

--- a/prover-service/src/utils.rs
+++ b/prover-service/src/utils.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Aptos Foundation
+
+use aptos_logger::error;
+use http::StatusCode;
+use serde::Serialize;
+use std::fmt::Debug;
+
+/// Serializes the given data to a pretty JSON string, and returns an appropriate HTTP status code
+pub fn to_json_string_pretty<T: Debug + Serialize>(data: &T) -> (StatusCode, String) {
+    match serde_json::to_string_pretty(&data) {
+        Ok(string) => (StatusCode::OK, string),
+        Err(error) => {
+            // Log and return the error
+            let error_string = format!(
+                "Failed to serialize data to JSON: {:?}. Error: {}",
+                data, error
+            );
+            error!("{}", error_string);
+
+            (StatusCode::INTERNAL_SERVER_ERROR, error_string)
+        }
+    }
+}


### PR DESCRIPTION
# What is the change being pushed?
This PR offers the following commits:
1. Add a new `/about` endpoint to the prover service to expose build information (this is the same endpoint as exposed by the pepper service, e.g., [here](https://pepper.keyless.testnet.aptoslabs.com/about)).
2. Move the `/meta` endpoint to `/config`, as the endpoint just returns the prover service config. Note: it makes sense to keep these endpoints separate, as it avoids overlapping concerns (i.e., config vs build information).

# Testing Plan
Manual verification. Tests will be added once we've added a test framework.
