### PR TITLE
[Prover] Remove PRIVATE_KEY_0 env variable and use binary args.

### DIFF
--- a/prover-service/src/handlers.rs
+++ b/prover-service/src/handlers.rs
@@ -79,9 +79,13 @@ pub async fn prove_handler(
         // As a result, whenever the VK changes on-chain, the TW PK must change too.
         // Otherwise, an old proof computed for an old VK will pass the TW signature check, even though this proof will not verify under the new VK.
         let training_wheels_signature = EphemeralSignature::ed25519(
-            training_wheels::sign(&state.tw_keys.signing_key, proof, public_inputs_hash)
-                .map_err(anyhow::Error::from)
-                .log_err()?,
+            training_wheels::sign(
+                &state.training_wheels_key_pair.signing_key,
+                proof,
+                public_inputs_hash,
+            )
+            .map_err(anyhow::Error::from)
+            .log_err()?,
         );
 
         let response = ProverServiceResponse::Success {
@@ -91,7 +95,11 @@ pub async fn prove_handler(
         };
 
         if state.prover_service_config.enable_debug_checks {
-            assert!(training_wheels::verify(&response, &state.tw_keys.verification_key).is_ok());
+            assert!(training_wheels::verify(
+                &response,
+                &state.training_wheels_key_pair.verification_key
+            )
+            .is_ok());
         }
 
         Ok(Json(response))

--- a/prover-service/src/tests/common/mod.rs
+++ b/prover-service/src/tests/common/mod.rs
@@ -120,8 +120,10 @@ pub async fn convert_prove_and_verify(
         prover_service_config,
         circuit_config: testcase.prover_service_config.load_circuit_params(),
         deployment_information: DeploymentInformation::new(),
-        groth16_vk: testcase.prover_service_config.load_test_verification_key(),
-        tw_keys: TrainingWheelsKeyPair::from_sk(tw_sk_default),
+        on_chain_groth16_verification_key: testcase
+            .prover_service_config
+            .load_test_verification_key(),
+        training_wheels_key_pair: TrainingWheelsKeyPair::from_sk(tw_sk_default),
         full_prover: Mutex::new(
             FullProver::new(testcase.prover_service_config.zkey_file_path().as_str()).unwrap(),
         ),

--- a/scripts/run_prover_service.sh
+++ b/scripts/run_prover_service.sh
@@ -14,4 +14,6 @@ export PRIVATE_KEY_0=$(cat ./prover-service/private_key_for_testing.txt)
 
 # Run the prover service.
 # TODO: handle the libtbb.dylib issue on macOS.
-cargo run -p prover-service -- --config-file-path ./prover-service/config_local_testing.yml
+cargo run -p prover-service -- \
+--config-file-path ./prover-service/config_local_testing.yml \
+--training-wheels-private-key-file-path ./prover-service/private_key_for_testing.txt


### PR DESCRIPTION
Note: this PR is built on: https://github.com/aptos-labs/keyless-zk-proofs/pull/87

# What is the change being pushed?
This PR removes the training wheels private key environment variable and uses binary args instead. This makes the private key requirement clearer and more explicit. It'll also make things easier to test later on.

Note: the PR also exposes the training wheels verification key (public key) in the `/about` endpoint of the prover service. This allows us to verify the active key at runtime.

# Testing Plan
Manual verification.