### PR TITLE
[Prover] Cleanups to the metrics server, `main.rs` and related files.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,11 +15,3 @@ xclippy = [
 
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
-
-
-[env]
-# These are required for renaming axum metrics to be specific to prover
-AXUM_HTTP_REQUESTS_TOTAL = "prover_requests_total"
-AXUM_HTTP_REQUESTS_DURATION_SECONDS = "prover_request_duration_secs"
-AXUM_HTTP_REQUESTS_PENDING = "prover_requests_pending"
-AXUM_HTTP_RESPONSE_BODY_SIZE = "prover_response_body_size"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "aptos-bitvec"
@@ -406,6 +406,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "aptos-metrics-core"
+version = "0.1.0"
+source = "git+https://github.com/aptos-labs/aptos-core?rev=0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627#0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "paste",
+ "prometheus",
 ]
 
 [[package]]
@@ -799,28 +810,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-prometheus"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683cbc43010e9a3d72c2f31ca464155ff4f95819e88a32924b0f47a43898978"
-dependencies = [
- "axum",
- "bytes",
- "futures",
- "futures-core",
- "http 1.1.0",
- "http-body 1.0.0",
- "matchit",
- "metrics",
- "metrics-exporter-prometheus",
- "once_cell",
- "pin-project",
- "tokio",
- "tower",
- "tower-http",
 ]
 
 [[package]]
@@ -3063,48 +3052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
-dependencies = [
- "ahash 0.8.11",
- "portable-atomic",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
-dependencies = [
- "base64 0.21.7",
- "hyper 0.14.28",
- "indexmap 2.5.0",
- "ipnet",
- "metrics",
- "metrics-util",
- "quanta",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.14.3",
- "metrics",
- "num_cpus",
- "quanta",
- "sketches-ddsketch",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,12 +3900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
-
-[[package]]
 name = "poseidon-ark"
 version = "0.0.1"
 source = "git+https://github.com/arnaucube/poseidon-ark.git?rev=6d2487aa1308d9d3860a2b724c485d73095c1c68#6d2487aa1308d9d3860a2b724c485d73095c1c68"
@@ -4096,6 +4037,7 @@ dependencies = [
  "aptos-infallible 0.1.0 (git+https://github.com/aptos-labs/aptos-core?rev=0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627)",
  "aptos-keyless-common",
  "aptos-logger",
+ "aptos-metrics-core",
  "aptos-types",
  "ark-bn254",
  "ark-ff",
@@ -4103,7 +4045,6 @@ dependencies = [
  "ark-serialize",
  "axum",
  "axum-extra",
- "axum-prometheus",
  "base64 0.13.1",
  "bcs",
  "clap 4.5.51",
@@ -4111,6 +4052,7 @@ dependencies = [
  "figment",
  "hex",
  "http 1.1.0",
+ "hyper 0.14.28",
  "jsonwebtoken",
  "maplit2",
  "num-bigint 0.4.4",
@@ -4142,21 +4084,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "quanta"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -4286,15 +4213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
-dependencies = [
- "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -4948,12 +4866,6 @@ dependencies = [
  "thiserror",
  "time",
 ]
-
-[[package]]
-name = "sketches-ddsketch"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ repository = "https://github.com/aptos-labs/keyless-zk-proofs"
 rust-version = "1.85.0"
 
 [workspace.dependencies]
-anyhow = "1.0.79"
+anyhow = "1.0.98"
 aptos-build-info = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
 aptos-crypto = { git = "https://github.com/aptos-labs/aptos-core", branch = "main" } # TODO: pin to a specific rev
 aptos-crypto-derive = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
 aptos-infallible = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
 aptos-keyless-common = { path = "keyless-common" }
 aptos-logger = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
+aptos-metrics-core = { git = "https://github.com/aptos-labs/aptos-core", rev = "0ce3ac3a3e51c57b7e02ca8ed9010f6eda67d627" }
 aptos-types = { git = "https://github.com/aptos-labs/aptos-core", branch = "main" } # TODO: pin to a specific rev
 ark-bn254 = "0.4.0"
 ark-ff = "0.4.0"
@@ -27,7 +28,6 @@ ark-groth16 = "0.4.0"
 ark-serialize = "0.4.0"
 axum = "0.7.4"
 axum-extra = "0.9.2"
-axum-prometheus = { version = "0.6.1", features = ["prometheus"] }
 base64 = "0.13.0"
 bcs = { git = "https://github.com/aptos-labs/bcs.git", rev = "d31fab9d81748e2594be5cd5cdf845786a30562d" }
 bindgen = "0.69.2"
@@ -42,6 +42,7 @@ dashmap = "5.5.3"
 figment = { version = "0.10.14", features = ["yaml", "env"] }
 hex = { version = "0.4.3", features = ["serde"] }
 http = "1.0.0"
+hyper = { version = "0.14.18", features = ["full"] }
 itertools = "0.13"
 jsonwebtoken = "8.1"
 maplit2 = "1.0.5"

--- a/prover-service/Cargo.toml
+++ b/prover-service/Cargo.toml
@@ -20,6 +20,7 @@ aptos-crypto-derive = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-keyless-common = { workspace = true }
 aptos-logger = { workspace = true }
+aptos-metrics-core = { workspace = true }
 aptos-types = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ff = { workspace = true }
@@ -27,7 +28,6 @@ ark-groth16 = { workspace = true }
 ark-serialize = { workspace = true }
 axum = { workspace = true }
 axum-extra = { workspace = true }
-axum-prometheus = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
 clap = { workspace = true }
@@ -35,6 +35,7 @@ dashmap = { workspace = true }
 figment = { workspace = true }
 hex = { workspace = true }
 http = { workspace = true }
+hyper = { workspace = true }
 jsonwebtoken = { workspace = true }
 maplit2 = { workspace = true }
 num-bigint = { workspace = true }

--- a/prover-service/src/deployment_information.rs
+++ b/prover-service/src/deployment_information.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_build_info::build_information;
+use aptos_crypto::ed25519::Ed25519PublicKey;
 use aptos_infallible::Mutex;
 use std::{collections::BTreeMap, sync::Arc};
+
+// The key used to store the training wheels verification key in the deployment information
+const TRAINING_WHEELS_VERIFICATION_KEY: &str = "training_wheels_verification_key";
 
 /// A simple struct to hold deployment information as key-value pairs
 #[derive(Clone, Debug)]
@@ -37,4 +41,21 @@ impl Default for DeploymentInformation {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Creates and returns the deployment information for the prover service
+pub fn get_deployment_information(
+    training_wheels_verification_key: &Ed25519PublicKey,
+) -> DeploymentInformation {
+    // Create the deployment information
+    let mut deployment_information = DeploymentInformation::new();
+
+    // Insert the training wheels verification key into the deployment information.
+    // This is useful for runtime verification (e.g., to ensure the correct key is being used).
+    deployment_information.extend_deployment_information(
+        TRAINING_WHEELS_VERIFICATION_KEY.into(),
+        training_wheels_verification_key.to_string(),
+    );
+
+    deployment_information
 }

--- a/prover-service/src/metrics.rs
+++ b/prover-service/src/metrics.rs
@@ -1,25 +1,22 @@
 // Copyright (c) Aptos Foundation
 
+use aptos_logger::{error, warn};
+use aptos_metrics_core::{
+    register_histogram, register_int_counter_vec, Histogram, IntCounterVec, TextEncoder,
+};
+use hyper::header::CONTENT_TYPE;
+use hyper::{Body, Method, StatusCode};
 use once_cell::sync::Lazy;
-use prometheus::{register_histogram, Histogram};
+use prometheus::{proto::MetricFamily, Encoder};
+use std::convert::Infallible;
 
-pub static PROVER_TIME_SECS: Lazy<Histogram> =
-    Lazy::new(|| register_histogram!("prover_time_secs", "Prover time in seconds",).unwrap());
+// TODO: sanity check and expand these metrics!
 
 pub static GROTH16_TIME_SECS: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "prover_groth16_time_secs",
         "Time to run Groth16 in seconds",
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 20.0]
-    )
-    .unwrap()
-});
-
-pub static WITNESS_TIME_SECS: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
-        "prover_witness_generation_time_secs",
-        "Witness generation time in seconds",
-        vec![0.25, 0.5, 0.75, 1.0, 2.0]
     )
     .unwrap()
 });
@@ -32,3 +29,85 @@ pub static REQUEST_QUEUE_TIME_SECS: Lazy<Histogram> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Counter for the number of metrics in various states
+pub static NUM_METRICS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_metrics",
+        "Number of metrics in certain states",
+        &["type"]
+    )
+    .unwrap()
+});
+
+/// Handles incoming HTTP requests for the metrics server
+pub async fn handle_metrics_request(
+    request: hyper::Request<Body>,
+) -> Result<hyper::Response<Body>, Infallible> {
+    let response = match (request.method(), request.uri().path()) {
+        (&Method::GET, "/metrics") => {
+            let buffer = get_encoded_metrics(TextEncoder::new());
+            hyper::Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "text/plain")
+                .body(Body::from(buffer))
+                .expect("Metric response should build")
+        }
+        _ => {
+            let mut response = hyper::Response::new(Body::empty());
+            *response.status_mut() = StatusCode::NOT_FOUND;
+            response
+        }
+    };
+    Ok(response)
+}
+
+/// A simple utility function that encodes the metrics using the given encoder
+fn get_encoded_metrics(encoder: impl Encoder) -> Vec<u8> {
+    // Gather and encode the metrics
+    let metric_families = get_metric_families();
+    let mut encoded_buffer = vec![];
+    if let Err(error) = encoder.encode(&metric_families, &mut encoded_buffer) {
+        error!("Failed to encode metrics! Error: {}", error);
+        return vec![];
+    }
+
+    // Update the total metric bytes counter
+    NUM_METRICS
+        .with_label_values(&["total_bytes"])
+        .inc_by(encoded_buffer.len() as u64);
+
+    encoded_buffer
+}
+
+/// A simple utility function that returns all metric families
+fn get_metric_families() -> Vec<MetricFamily> {
+    let metric_families = aptos_metrics_core::gather();
+    let mut total: u64 = 0;
+    let mut families_over_2000: u64 = 0;
+
+    // Take metrics of metric gathering so we know possible overhead of this process
+    for metric_family in &metric_families {
+        let family_count = metric_family.get_metric().len();
+        if family_count > 2000 {
+            families_over_2000 = families_over_2000.saturating_add(1);
+            let name = metric_family.get_name();
+            warn!(
+                count = family_count,
+                metric_family = name,
+                "Metric Family '{}' over 2000 dimensions '{}'",
+                name,
+                family_count
+            );
+        }
+        total = total.saturating_add(family_count as u64);
+    }
+
+    // These metrics will be reported on the next pull, rather than create a new family
+    NUM_METRICS.with_label_values(&["total"]).inc_by(total);
+    NUM_METRICS
+        .with_label_values(&["families_over_2000"])
+        .inc_by(families_over_2000);
+
+    metric_families
+}

--- a/prover-service/src/metrics.rs
+++ b/prover-service/src/metrics.rs
@@ -1,14 +1,27 @@
 // Copyright (c) Aptos Foundation
 
-use aptos_logger::{error, warn};
+use crate::prover_config::ProverServiceConfig;
+use aptos_logger::{error, info, warn};
 use aptos_metrics_core::{
     register_histogram, register_int_counter_vec, Histogram, IntCounterVec, TextEncoder,
 };
 use hyper::header::CONTENT_TYPE;
-use hyper::{Body, Method, StatusCode};
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Method, Server, StatusCode};
 use once_cell::sync::Lazy;
 use prometheus::{proto::MetricFamily, Encoder};
 use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+// Constants for the metrics endpoint and response type
+const METRICS_ENDPOINT: &str = "/metrics";
+const PLAIN_CONTENT_TYPE: &str = "text/plain";
+
+// Useful metric labels for counting all metrics
+const TOTAL_METRIC_BYTES_LABEL: &str = "total_bytes";
+const TOTAL_METRIC_FAMILIES_OVER_2000_LABEL: &str = "families_over_2000";
+const TOTAL_METRICS_LABEL: &str = "total";
 
 // TODO: sanity check and expand these metrics!
 
@@ -30,28 +43,47 @@ pub static REQUEST_QUEUE_TIME_SECS: Lazy<Histogram> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Counter for the number of metrics in various states
-pub static NUM_METRICS: Lazy<IntCounterVec> = Lazy::new(|| {
+/// Counter for the number of prover metrics in various states
+pub static PROVER_NUM_METRICS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "aptos_metrics",
-        "Number of metrics in certain states",
+        "keyless_prover_num_metrics",
+        "Number of keyless prover metrics in certain states",
         &["type"]
     )
     .unwrap()
 });
 
+// Starts a simple metrics server
+pub fn start_metrics_server(prover_service_config: Arc<ProverServiceConfig>) {
+    let _handle = tokio::spawn(async move {
+        info!("Starting metrics server request handler...");
+
+        // Create a service function that handles the metrics requests
+        let make_service = make_service_fn(|_conn| async {
+            Ok::<_, Infallible>(service_fn(handle_metrics_request))
+        });
+
+        // Bind the socket address, and start the server
+        let socket_addr = SocketAddr::from(([0, 0, 0, 0], prover_service_config.metrics_port));
+        let server = Server::bind(&socket_addr).serve(make_service);
+        if let Err(error) = server.await {
+            panic!("Metrics server error! Error: {}", error);
+        }
+    });
+}
+
 /// Handles incoming HTTP requests for the metrics server
-pub async fn handle_metrics_request(
+async fn handle_metrics_request(
     request: hyper::Request<Body>,
 ) -> Result<hyper::Response<Body>, Infallible> {
     let response = match (request.method(), request.uri().path()) {
-        (&Method::GET, "/metrics") => {
+        (&Method::GET, METRICS_ENDPOINT) => {
             let buffer = get_encoded_metrics(TextEncoder::new());
             hyper::Response::builder()
                 .status(StatusCode::OK)
-                .header(CONTENT_TYPE, "text/plain")
+                .header(CONTENT_TYPE, PLAIN_CONTENT_TYPE)
                 .body(Body::from(buffer))
-                .expect("Metric response should build")
+                .expect("The metric response failed to build!")
         }
         _ => {
             let mut response = hyper::Response::new(Body::empty());
@@ -73,8 +105,8 @@ fn get_encoded_metrics(encoder: impl Encoder) -> Vec<u8> {
     }
 
     // Update the total metric bytes counter
-    NUM_METRICS
-        .with_label_values(&["total_bytes"])
+    PROVER_NUM_METRICS
+        .with_label_values(&[TOTAL_METRIC_BYTES_LABEL])
         .inc_by(encoded_buffer.len() as u64);
 
     encoded_buffer
@@ -104,9 +136,11 @@ fn get_metric_families() -> Vec<MetricFamily> {
     }
 
     // These metrics will be reported on the next pull, rather than create a new family
-    NUM_METRICS.with_label_values(&["total"]).inc_by(total);
-    NUM_METRICS
-        .with_label_values(&["families_over_2000"])
+    PROVER_NUM_METRICS
+        .with_label_values(&[TOTAL_METRICS_LABEL])
+        .inc_by(total);
+    PROVER_NUM_METRICS
+        .with_label_values(&[TOTAL_METRIC_FAMILIES_OVER_2000_LABEL])
         .inc_by(families_over_2000);
 
     metric_families

--- a/prover-service/src/prover_config.rs
+++ b/prover-service/src/prover_config.rs
@@ -3,8 +3,10 @@
 use crate::groth16_vk::{OnChainGroth16VerificationKey, SnarkJsGroth16VerificationKey};
 use crate::utils;
 use aptos_keyless_common::input_processing::config::CircuitConfig;
+use aptos_logger::info;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 // Constants for the prover service configuration file
 const CIRCUIT_CONFIG_YML_FILE_NAME: &str = "circuit_config.yml";
@@ -135,6 +137,35 @@ impl ProverServiceConfig {
             ),
         }
     }
+}
+
+/// Loads the prover service config from the specified file path.
+/// If the file cannot be read or parsed, this function will panic.
+pub fn load_prover_service_config(config_file_path: &str) -> Arc<ProverServiceConfig> {
+    info!(
+        "Loading the prover service config file from path: {}",
+        config_file_path
+    );
+
+    // Read the config file contents
+    let config_file_contents = utils::read_string_from_file_path(config_file_path);
+
+    // Parse the config file contents into the config struct
+    let prover_service_config = match serde_yaml::from_str(&config_file_contents) {
+        Ok(prover_service_config) => {
+            info!(
+                "Loaded the prover service config: {:?}",
+                prover_service_config
+            );
+            prover_service_config
+        }
+        Err(error) => panic!(
+            "Failed to parse prover service config yaml file: {}! Error: {}",
+            config_file_path, error
+        ),
+    };
+
+    Arc::new(prover_service_config)
 }
 
 /// Expands the tilde in a given path

--- a/scripts/run_prover_service.sh
+++ b/scripts/run_prover_service.sh
@@ -5,9 +5,6 @@
 # Set appropriate script flags.
 set -ex
 
-# Export the private key environment variable (for testing)
-export PRIVATE_KEY_0=$(cat ./prover-service/private_key_for_testing.txt)
-
 # Procure a testing setup to generate the Groth16 proving key.
 # Note: this can take ~10 minutes the first time it is run.
 ./scripts/task.sh setup procure-testing-setup


### PR DESCRIPTION
# What is the change being pushed?
This PR offers the following commits:
1. Quick pass over the release helper (and small cleanups). Nothing should change.
2. Remove AXUM env variables (these are not required).
3. Replace the "custom" metrics server code with the same metrics server code used by the pepper service (and the `aptos-node` binary).
4.  Small cleanups across `main.rs`, and several other linked files.

# Testing Plan
Existing test infrastructure, and manual verification (locally).
