### PR TITLE
[Prover] Always verify the TW signature, and rename the test verification key.

### DIFF
--- a/prover-service/config.yml
+++ b/prover-service/config.yml
@@ -2,12 +2,11 @@ resources_dir: "/resources/ceremonies"
 setup_dir: "default"
 zkey_filename: "prover_key.zkey"
 witness_gen_binary_filename: "main_c"
-test_verification_key_filename: "verification_key.json"
+verification_key_filename: "verification_key.json"
 oidc_providers:
   - iss: "https://accounts.google.com"
     endpoint_url: "https://www.googleapis.com/oauth2/v3/certs"
 jwk_refresh_rate_secs: 10
 port: 8080
 metrics_port: 9100
-enable_debug_checks: false
 enable_federated_jwks: false

--- a/prover-service/config_local_testing.yml
+++ b/prover-service/config_local_testing.yml
@@ -2,7 +2,7 @@ resources_dir: "~/.local/share/aptos-keyless/current_setups"
 setup_dir: "default"
 zkey_filename: "prover_key.zkey"
 witness_gen_binary_filename: "main_c"
-test_verification_key_filename: "verification_key.json"
+verification_key_filename: "verification_key.json"
 oidc_providers:
   - iss: "https://accounts.google.com"
     endpoint_url: "https://www.googleapis.com/oauth2/v3/certs"
@@ -13,7 +13,6 @@ oidc_providers:
 jwk_refresh_rate_secs: 10
 port: 8083
 metrics_port: 9100
-enable_debug_checks: true
 enable_test_provider: true
 enable_federated_jwks: true
 use_insecure_jwk_for_test: true

--- a/prover-service/src/main.rs
+++ b/prover-service/src/main.rs
@@ -53,8 +53,8 @@ async fn main() {
         deployment_information,
     ));
 
-    // Load the test verification key
-    load_test_verification_key(prover_service_config.clone());
+    // Load the verification key
+    load_verification_key(prover_service_config.clone());
 
     // init jwk fetching job; refresh every `config.jwk_refresh_rate_secs` seconds
     jwk_fetching::init_jwk_fetching(
@@ -70,13 +70,11 @@ async fn main() {
     start_prover_service(prover_service_config.port, prover_service_state).await;
 }
 
-/// Loads and logs the test verification key from the prover service config
-fn load_test_verification_key(prover_service_config: Arc<ProverServiceConfig>) {
-    // TODO: what does this actually do? Is it still useful?
-
-    let test_verification_key_file_path = prover_service_config.test_verification_key_file_path();
-    let test_verification_key = utils::read_string_from_file_path(&test_verification_key_file_path);
-    info!("Loaded default verifying Key: {}", test_verification_key);
+/// Loads and logs the verification key from the prover service config
+fn load_verification_key(prover_service_config: Arc<ProverServiceConfig>) {
+    let verification_key_file_path = prover_service_config.verification_key_file_path();
+    let verification_key = utils::read_string_from_file_path(&verification_key_file_path);
+    info!("Loaded default verifying Key: {}", verification_key);
 }
 
 /// Loads the training wheels key pair from the specified private key file path.

--- a/prover-service/src/tests/common/mod.rs
+++ b/prover-service/src/tests/common/mod.rs
@@ -156,12 +156,8 @@ pub async fn convert_prove_and_verify(
             public_inputs_hash,
             ..
         } => {
-            let g16vk = prepared_vk(
-                &testcase
-                    .prover_service_config
-                    .test_verification_key_file_path(),
-            )
-            .unwrap();
+            let g16vk =
+                prepared_vk(&testcase.prover_service_config.verification_key_file_path()).unwrap();
             proof.verify_proof(public_inputs_hash.as_fr(), &g16vk)?;
             training_wheels::verify(&response, &tw_pk)
         }


### PR DESCRIPTION
# What is the change being pushed?
This PR updates the prover service to:
1. Always verify the training wheels signature (e.g., to avoid fault-based side-channel attacks).
2. Renames the `test_verification_key` to `verification_key` in the prover service config, as the key is not a test artifact. 

# Testing Plan
Existing test infrastructure.
