### PR TITLE
[Prover Service] Add JWK fetching tests, and tests for request handling

### DIFF
--- a/prover-service/src/external_resources/jwk_fetcher.rs
+++ b/prover-service/src/external_resources/jwk_fetcher.rs
@@ -47,7 +47,7 @@ pub trait JWKIssuerInterface {
 }
 
 /// A simple JWK issuer struct
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct JWKIssuer {
     issuer_name: String,
     issuer_jwk_url: String,

--- a/prover-service/src/external_resources/prover_config.rs
+++ b/prover-service/src/external_resources/prover_config.rs
@@ -14,7 +14,7 @@ const GENERATE_WITNESS_JS_FILE_NAME: &str = "generate_witness.js";
 const MAIN_WASM_FILE_NAME: &str = "main.wasm";
 
 /// The prover service configuration
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct ProverServiceConfig {
     pub setup_dir: String,

--- a/prover-service/src/request_handler/handler.rs
+++ b/prover-service/src/request_handler/handler.rs
@@ -16,11 +16,11 @@ use std::{convert::Infallible, sync::Arc};
 
 // The list of endpoints/paths offered by the Prover Service.
 // Note: if you update these paths, please also update the "ALL_PATHS" array below.
-const ABOUT_PATH: &str = "/about";
-const CONFIG_PATH: &str = "/config";
-const HEALTH_CHECK_PATH: &str = "/healthcheck";
+pub const ABOUT_PATH: &str = "/about";
+pub const CONFIG_PATH: &str = "/config";
+pub const HEALTH_CHECK_PATH: &str = "/healthcheck";
 pub const JWK_PATH: &str = "/cached/jwk";
-const PROVE_PATH: &str = "/v0/prove";
+pub const PROVE_PATH: &str = "/v0/prove";
 
 // An array of all known endpoints/paths
 pub const ALL_PATHS: [&str; 5] = [

--- a/prover-service/src/request_handler/prover_handler.rs
+++ b/prover-service/src/request_handler/prover_handler.rs
@@ -232,13 +232,20 @@ async fn generate_groth16_proof(
     // Generate the JSON proof
     let full_prover = prover_service_state.full_prover();
     let full_prover_locked = full_prover.lock().await;
-    let (proof_json, _internal_metrics) = match full_prover_locked.prove(witness_file_path) {
-        Ok((proof_json, metrics)) => (proof_json.to_string(), metrics),
-        Err(error) => {
-            return Err(ProverServiceError::UnexpectedError(format!(
-                "Failed to generate rapidsnark proof! Error: {:?}",
-                error
-            )));
+    let (proof_json, _internal_metrics) = match full_prover_locked.as_ref() {
+        Some(full_prover_locked) => match full_prover_locked.prove(witness_file_path) {
+            Ok((proof_json, metrics)) => (proof_json.to_string(), metrics),
+            Err(error) => {
+                return Err(ProverServiceError::UnexpectedError(format!(
+                    "Failed to generate rapidsnark proof! Error: {:?}",
+                    error
+                )));
+            }
+        },
+        None => {
+            return Err(ProverServiceError::UnexpectedError(
+                "The full prover was not initialized correctly!".into(),
+            ));
         }
     };
 

--- a/prover-service/src/tests/federated_jwk.rs
+++ b/prover-service/src/tests/federated_jwk.rs
@@ -5,6 +5,8 @@ use crate::tests::common::gen_test_jwk_keypair_with_kid_override;
 use crate::tests::common::types::{ProofTestCase, TestJWTPayload};
 use aptos_keyless_common::input_processing::encoding::DecodedJWT;
 
+// TODO: avoid the external test dependencies!
+
 // This test uses a demo auth0 tenant owned by oliver.he@aptoslabs.com
 #[tokio::test]
 async fn test_federated_jwk_fetch() {

--- a/prover-service/src/tests/jwk_fetcher.rs
+++ b/prover-service/src/tests/jwk_fetcher.rs
@@ -1,0 +1,234 @@
+// Copyright (c) Aptos Foundation
+
+use crate::{
+    error::ProverServiceError,
+    external_resources::{
+        jwk_fetcher,
+        jwk_fetcher::{JWKCache, JWKIssuerInterface, KeyID},
+    },
+};
+use aptos_infallible::Mutex;
+use aptos_time_service::TimeService;
+use aptos_types::{jwks, jwks::rsa::RSA_JWK};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::{task::JoinHandle, time::timeout};
+
+// Test issuer names for Apple and Google
+const ISSUER_APPLE: &str = "issuer_apple";
+const ISSUER_GOOGLE: &str = "issuer_google";
+
+// JWK refresh interval used in tests
+const JWK_REFRESH_INTERVAL_SECS: u64 = 10; // JWK refresh interval (secs)
+
+// Maximum wait time (secs) for each test to complete
+const MAX_TEST_WAIT_SECS: u64 = 10;
+
+/// A mock JWK issuer (for testing JWK fetching and caching)
+struct MockJWKIssuer {
+    issuer_name: String,
+    jwk_key_set: HashMap<KeyID, Arc<RSA_JWK>>,
+    num_fetch_failures: Arc<Mutex<u64>>, // The number of fetch failures to simulate
+}
+
+impl MockJWKIssuer {
+    pub fn new(
+        issuer_name: String,
+        jwk_key_set: HashMap<KeyID, Arc<RSA_JWK>>,
+        num_fetch_failures: u64,
+    ) -> Self {
+        Self {
+            issuer_name,
+            jwk_key_set,
+            num_fetch_failures: Arc::new(Mutex::new(num_fetch_failures)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl JWKIssuerInterface for MockJWKIssuer {
+    fn issuer_name(&self) -> String {
+        self.issuer_name.clone()
+    }
+
+    fn issuer_jwk_url(&self) -> String {
+        "".into() // The URL is not used in the mock implementation
+    }
+
+    async fn fetch_jwks(&self) -> anyhow::Result<HashMap<KeyID, Arc<RSA_JWK>>> {
+        // If there are failures to simulate, decrement the counter and
+        // return an error, otherwise, return the JWK key set.
+        let mut num_fetch_failures = self.num_fetch_failures.lock();
+        if *num_fetch_failures > 0 {
+            *num_fetch_failures -= 1;
+            Err(anyhow::anyhow!(
+                "Simulated fetch failure for issuer {}! Failures remaining: {}",
+                self.issuer_name,
+                *num_fetch_failures
+            ))
+        } else {
+            Ok(self.jwk_key_set.clone())
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn jwk_cache_updates_after_interval() {
+    // Create test JWK key sets
+    let apple_jwk_key_set = create_test_jwk_key_set(ISSUER_APPLE.into());
+    let google_jwk_key_set = create_test_jwk_key_set(ISSUER_GOOGLE.into());
+
+    // Create mock JWK issuers for Apple and Google
+    let apple_jwk_issuer = Arc::new(MockJWKIssuer::new(
+        ISSUER_APPLE.into(),
+        apple_jwk_key_set.clone(),
+        0,
+    ));
+    let google_jwk_issuer = Arc::new(MockJWKIssuer::new(
+        ISSUER_GOOGLE.into(),
+        google_jwk_key_set.clone(),
+        0,
+    ));
+
+    // Verify that the JWK cache is updated correctly
+    verify_jwk_cache_updates(
+        apple_jwk_key_set,
+        google_jwk_key_set,
+        apple_jwk_issuer,
+        google_jwk_issuer,
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn jwk_cache_updates_after_failures() {
+    // Create test JWK key sets
+    let apple_jwk_key_set = create_test_jwk_key_set(ISSUER_APPLE.into());
+    let google_jwk_key_set = create_test_jwk_key_set(ISSUER_GOOGLE.into());
+
+    // Create mock JWK issuers that fail a few times before succeeding
+    let num_fetch_failures = 3;
+    let apple_jwk_issuer = Arc::new(MockJWKIssuer::new(
+        ISSUER_APPLE.into(),
+        apple_jwk_key_set.clone(),
+        num_fetch_failures,
+    ));
+    let google_jwk_issuer = Arc::new(MockJWKIssuer::new(
+        ISSUER_GOOGLE.into(),
+        google_jwk_key_set.clone(),
+        num_fetch_failures,
+    ));
+
+    // Verify that the JWK cache is updated correctly
+    verify_jwk_cache_updates(
+        apple_jwk_key_set,
+        google_jwk_key_set,
+        apple_jwk_issuer,
+        google_jwk_issuer,
+    )
+    .await;
+}
+
+/// Advances the mock time service by the given number of seconds
+async fn advance_time_secs(time_service: TimeService, seconds: u64) {
+    let mock_time_service = time_service.into_mock();
+    mock_time_service
+        .advance_async(Duration::from_secs(seconds))
+        .await;
+}
+
+/// Creates a JWK cache and starts the refresh loops for known issuers
+fn create_and_start_jwk_cache(
+    apple_jwk_issuer: Arc<dyn JWKIssuerInterface + Send + Sync>,
+    google_jwk_issuer: Arc<dyn JWKIssuerInterface + Send + Sync>,
+    time_service: TimeService,
+) -> JWKCache {
+    // Create the JWK cache
+    let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
+
+    // Start the JWK refresh loops for Apple and Google
+    let jwk_refresh_rate = Duration::from_secs(JWK_REFRESH_INTERVAL_SECS);
+    jwk_fetcher::start_jwk_refresh_loop(
+        apple_jwk_issuer,
+        jwk_cache.clone(),
+        jwk_refresh_rate,
+        time_service.clone(),
+    );
+    jwk_fetcher::start_jwk_refresh_loop(
+        google_jwk_issuer,
+        jwk_cache.clone(),
+        jwk_refresh_rate,
+        time_service,
+    );
+
+    jwk_cache
+}
+
+/// Creates a test JWK key set with a single RSA key
+fn create_test_jwk_key_set(issuer_name: String) -> HashMap<KeyID, Arc<RSA_JWK>> {
+    // Create several keys with different IDs
+    let mut key_set = HashMap::new();
+    for i in 0..5 {
+        let key_id = format!("{}_key_{}", issuer_name, i);
+        key_set.insert(key_id, Arc::new(jwks::insecure_test_rsa_jwk()));
+    }
+
+    key_set
+}
+
+/// Verifies that the cached resources are eventually updated
+/// correctly after the resource fetcher is started.
+async fn verify_jwk_cache_updates(
+    apple_jwk_key_set: HashMap<KeyID, Arc<RSA_JWK>>,
+    google_jwk_key_set: HashMap<KeyID, Arc<RSA_JWK>>,
+    apple_jwk_issuer: Arc<dyn JWKIssuerInterface + Send + Sync>,
+    google_jwk_issuer: Arc<dyn JWKIssuerInterface + Send + Sync>,
+) {
+    // Create the JWK cache and start the refresh loops
+    let time_service = TimeService::mock();
+    let jwk_cache =
+        create_and_start_jwk_cache(apple_jwk_issuer, google_jwk_issuer, time_service.clone());
+
+    // Verify that initially the cache is empty
+    assert!(jwk_cache.lock().get(ISSUER_APPLE).is_none());
+    assert!(jwk_cache.lock().get(ISSUER_GOOGLE).is_none());
+
+    // Spawn a task that advances time and verifies the cache is eventually updated
+    let cache_verification_task: JoinHandle<Result<(), ProverServiceError>> = tokio::spawn({
+        let time_service = time_service.clone();
+        let jwk_cache = jwk_cache.clone();
+
+        async move {
+            loop {
+                // Advance time by the refresh interval
+                advance_time_secs(time_service.clone(), JWK_REFRESH_INTERVAL_SECS + 1).await;
+
+                // Grab the cached key sets
+                let cached_apple_jwk_set = jwk_cache.lock().get(ISSUER_APPLE).cloned();
+                let cached_google_jwk_set = jwk_cache.lock().get(ISSUER_GOOGLE).cloned();
+
+                // Check if the cache has been updated correctly
+                match (cached_apple_jwk_set, cached_google_jwk_set) {
+                    (Some(cached_apple_jwk_set), Some(cached_google_jwk_set)) => {
+                        assert_eq!(cached_apple_jwk_set, apple_jwk_key_set);
+                        assert_eq!(cached_google_jwk_set, google_jwk_key_set);
+                        return Ok(());
+                    }
+                    _ => {
+                        // Yield to allow other tasks to run
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
+        }
+    });
+
+    // Verify that the JWK cache is eventually updated
+    if let Err(error) = timeout(
+        Duration::from_secs(MAX_TEST_WAIT_SECS),
+        cache_verification_task,
+    )
+    .await
+    {
+        panic!("Failed waiting for JWK cache to be updated: {}", error);
+    }
+}

--- a/prover-service/src/tests/mod.rs
+++ b/prover-service/src/tests/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 
 pub mod common;
-pub mod jwk_fetching;
+pub mod federated_jwk;
 pub mod playground;
 pub mod smoke;
 pub mod training_wheels;

--- a/prover-service/src/tests/mod.rs
+++ b/prover-service/src/tests/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod common;
 pub mod federated_jwk;
+pub mod jwk_fetcher;
 pub mod playground;
 pub mod smoke;
 pub mod training_wheels;

--- a/prover-service/src/tests/mod.rs
+++ b/prover-service/src/tests/mod.rs
@@ -4,5 +4,6 @@ pub mod common;
 pub mod federated_jwk;
 pub mod jwk_fetcher;
 pub mod playground;
+pub mod request_handler;
 pub mod smoke;
 pub mod training_wheels;

--- a/prover-service/src/tests/request_handler.rs
+++ b/prover-service/src/tests/request_handler.rs
@@ -1,0 +1,338 @@
+// Copyright (c) Aptos Foundation
+
+use crate::external_resources::jwk_fetcher::JWKCache;
+use crate::external_resources::prover_config::ProverServiceConfig;
+use crate::request_handler::deployment_information::DeploymentInformation;
+use crate::request_handler::handler;
+use crate::request_handler::handler::{
+    ABOUT_PATH, CONFIG_PATH, HEALTH_CHECK_PATH, JWK_PATH, PROVE_PATH,
+};
+use crate::request_handler::prover_state::{ProverServiceState, TrainingWheelsKeyPair};
+use aptos_infallible::Mutex;
+use aptos_types::jwks::rsa::SECURE_TEST_RSA_JWK;
+use hyper::{
+    header::{
+        ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    },
+    Body, Method, Request, Response, StatusCode,
+};
+use reqwest::header::ACCESS_CONTROL_ALLOW_CREDENTIALS;
+use std::ops::Deref;
+use std::{collections::HashMap, sync::Arc};
+
+#[tokio::test]
+async fn test_options_request() {
+    // Send an options request to the root path
+    let response =
+        send_request_to_path(Method::OPTIONS, "/", Body::empty(), None, None, None, None).await;
+
+    // Assert that the response status is OK
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify the response headers
+    let headers = response.headers();
+    assert_eq!(headers.get(ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(), "");
+    assert_eq!(
+        headers.get(ACCESS_CONTROL_ALLOW_CREDENTIALS).unwrap(),
+        "true"
+    );
+    assert_eq!(headers.get(ACCESS_CONTROL_ALLOW_HEADERS).unwrap(), "*");
+    assert_eq!(
+        headers.get(ACCESS_CONTROL_ALLOW_METHODS).unwrap(),
+        "GET, POST, OPTIONS"
+    );
+}
+
+#[tokio::test]
+async fn test_get_about_request() {
+    // Create a new deployment information object
+    let mut deployment_information = DeploymentInformation::new();
+
+    // Insert a test entry into the deployment information
+    let test_key = "test_key".to_string();
+    let test_value = "test_value".to_string();
+    deployment_information.extend_deployment_information(test_key.clone(), test_value.clone());
+
+    // Send a GET request to the about endpoint
+    let response = send_request_to_path(
+        Method::GET,
+        ABOUT_PATH,
+        Body::empty(),
+        None,
+        None,
+        Some(deployment_information),
+        None,
+    )
+    .await;
+
+    // Assert that the response status is OK
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Parse the response body as a JSON map
+    let body_string = get_response_body_string(response).await;
+    let json_value: serde_json::Value = serde_json::from_str(&body_string).unwrap();
+    let json_map = json_value.as_object().unwrap();
+
+    // Verify the response body contains relevant build information
+    assert!(json_map.contains_key("build_cargo_version"));
+    assert!(json_map.contains_key("build_commit_hash"));
+    assert!(json_map.contains_key("build_is_release_build"));
+
+    // Verify the test entry is present in the response body
+    assert_eq!(json_map.get(&test_key).unwrap(), test_value.as_str());
+}
+
+#[tokio::test]
+async fn test_get_config_request() {
+    // Create a new prover service config
+    let prover_service_config = ProverServiceConfig {
+        setup_dir: "custom/setup/directory/for/tests".into(),
+        ..ProverServiceConfig::default()
+    };
+    let prover_service_config = Arc::new(prover_service_config);
+
+    // Send a GET request to the config endpoint
+    let response = send_request_to_path(
+        Method::GET,
+        CONFIG_PATH,
+        Body::empty(),
+        Some(prover_service_config.clone()),
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    // Assert that the response is a 200
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify the config from the response body JSON
+    let body_string = get_response_body_string(response).await;
+    let response_config: ProverServiceConfig = serde_json::from_str(&body_string).unwrap();
+    assert_eq!(&response_config, prover_service_config.deref());
+}
+
+#[tokio::test]
+async fn test_health_check_request() {
+    // Send a GET request to the health check endpoint
+    let response = send_request_to_path(
+        Method::GET,
+        HEALTH_CHECK_PATH,
+        Body::empty(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    // Assert that the response status is OK
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_get_jwk_request() {
+    // Create a JWK cache
+    let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
+
+    // Send a GET request to the JWK endpoint
+    let response = send_request_to_path(
+        Method::GET,
+        JWK_PATH,
+        Body::empty(),
+        None,
+        None,
+        None,
+        Some(jwk_cache.clone()),
+    )
+    .await;
+
+    // Assert that the response status is OK
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Parse the response body string and verify that it is an empty JSON map
+    let body_string = get_response_body_string(response).await;
+    let json_value: serde_json::Value = serde_json::from_str(&body_string).unwrap();
+    let json_map = json_value.as_object().unwrap();
+    assert!(json_map.is_empty());
+
+    // Insert several test JWKs into the cache
+    for i in 0..3 {
+        // Create the test issuer and key ID
+        let test_issuer = format!("test.issuer.{}", i);
+        let test_key_id = format!("test.key.id.{}", i);
+
+        // Insert the test JWK into the cache
+        let mut jwk_cache = jwk_cache.lock();
+        let issuer_entry = jwk_cache.entry(test_issuer.clone()).or_default();
+        issuer_entry.insert(
+            test_key_id.clone(),
+            Arc::new(SECURE_TEST_RSA_JWK.deref().clone()),
+        );
+    }
+
+    // Send a GET request to the JWK endpoint
+    let response = send_request_to_path(
+        Method::GET,
+        JWK_PATH,
+        Body::empty(),
+        None,
+        None,
+        None,
+        Some(jwk_cache.clone()),
+    )
+    .await;
+
+    // Assert that the response status is OK
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Parse the response body as a JSON map, and verify the number of entries
+    let body_string = get_response_body_string(response).await;
+    let json_value: serde_json::Value = serde_json::from_str(&body_string).unwrap();
+    let json_map = json_value.as_object().unwrap();
+    assert_eq!(json_map.len(), 3);
+
+    // Verify that the map contains the expected JWKs
+    for i in 0..3 {
+        // Create the test issuer and key ID
+        let test_issuer = format!("test.issuer.{}", i);
+        let test_key_id = format!("test.key.id.{}", i);
+
+        // Verify that the map contains the issuer and key ID
+        let issuer_entry = json_map.get(&test_issuer).unwrap().as_object().unwrap();
+        assert_eq!(issuer_entry.len(), 1);
+        assert!(issuer_entry.contains_key(&test_key_id));
+    }
+}
+
+#[tokio::test]
+async fn test_get_invalid_path_or_method_request() {
+    // Send a GET request to an unknown endpoint and verify that it returns 404
+    let response = send_request_to_path(
+        Method::GET,
+        "/invalid_path",
+        Body::empty(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // Send a GET request to an endpoint that only supports POST requests, and verify that it returns 405
+    let response = send_request_to_path(
+        Method::GET,
+        PROVE_PATH,
+        Body::empty(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+
+    // Send a POST request to an endpoint that only supports GET requests, and verify that it returns 405
+    let response = send_request_to_path(
+        Method::POST,
+        ABOUT_PATH,
+        Body::empty(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn test_prove_request_bad_request() {
+    // Send a POST request to the prove endpoint
+    let response = send_request_to_path(
+        Method::POST,
+        PROVE_PATH,
+        Body::empty(),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    // Assert that the response is a 400 (bad request, since no body was provided)
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Send another POST request with an invalid JSON body
+    let response = send_request_to_path(
+        Method::POST,
+        PROVE_PATH,
+        Body::from("invalid_json"),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    // Assert that the response is a 400 (bad request, since the body was invalid JSON)
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Gets the response body as a string
+async fn get_response_body_string(response: Response<Body>) -> String {
+    let body_bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    String::from_utf8(body_bytes.to_vec()).unwrap()
+}
+
+// Calls the request handler with the given method, endpoint, and body
+async fn send_request_to_path(
+    method: Method,
+    endpoint: &str,
+    body: Body,
+    prover_service_config: Option<Arc<ProverServiceConfig>>,
+    training_wheels_key_pair: Option<TrainingWheelsKeyPair>,
+    deployment_information: Option<DeploymentInformation>,
+    jwk_cache: Option<JWKCache>,
+) -> Response<Body> {
+    // Get or create the prover service config
+    let prover_service_config =
+        prover_service_config.unwrap_or_else(|| Arc::new(ProverServiceConfig::default()));
+
+    // Build the URI
+    let uri = format!(
+        "http://127.0.0.1:{}{}",
+        prover_service_config.port, endpoint
+    );
+
+    // Build the request
+    let request = Request::builder()
+        .uri(uri)
+        .method(method)
+        .body(body)
+        .unwrap();
+
+    // Get or create a training wheels key pair
+    let training_wheels_key_pair =
+        training_wheels_key_pair.unwrap_or_else(TrainingWheelsKeyPair::new_for_testing);
+
+    // Get or create deployment information
+    let deployment_information = deployment_information.unwrap_or_default();
+
+    // Get or create a JWK cache
+    let jwk_cache = jwk_cache.unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())));
+
+    // Create the prover service state
+    let prover_service_state = Arc::new(ProverServiceState::new_for_testing(
+        training_wheels_key_pair,
+        prover_service_config,
+        deployment_information,
+        jwk_cache,
+    ));
+
+    // Serve the request
+    handler::handle_request(request, prover_service_state)
+        .await
+        .unwrap()
+}


### PR DESCRIPTION
# What is the change being pushed?
This PR offers the following commits:
1. Rename `jwk_fetching.rs` to `federated_jwk.rs` (as the file only contains federated JWK related tests).
2. Add JWK fetching tests (to ensure JWK fetching is handled correctly, and caches are updated appropriately).
3. Add request handling tests (to ensure request routing and service handling logic is correct).

# Testing Plan
New and existing test infrastructure.