### PR TITLE
[Prover Service] Remove external dependencies in federated JWK tests.

### DIFF
--- a/prover-service/src/external_resources/jwk_fetcher.rs
+++ b/prover-service/src/external_resources/jwk_fetcher.rs
@@ -1,5 +1,9 @@
 // Copyright (c) Aptos Foundation
 
+use crate::external_resources::jwk_types::{
+    FederatedJWKIssuer, FederatedJWKIssuerInterface, FederatedJWKs, JWKCache, JWKIssuer,
+    JWKIssuerInterface, KeyID,
+};
 use crate::{metrics, utils};
 use anyhow::{anyhow, Result};
 use aptos_infallible::Mutex;
@@ -7,9 +11,6 @@ use aptos_keyless_common::input_processing::jwt::DecodedJWT;
 use aptos_logger::{info, warn};
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::jwks::rsa::RSA_JWK;
-use once_cell::sync::Lazy;
-use regex::Regex;
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Instant;
@@ -19,66 +20,43 @@ use std::{sync::Arc, time::Duration};
 // The frequency at which to log the JWK refresh status (per loop iteration)
 const JWK_REFRESH_LOOP_LOG_FREQUENCY: u64 = 6; // e.g., 6 * 10s (per loop) = 60s per log
 
-// Useful type declarations
-pub type Issuer = String;
-pub type KeyID = String;
-pub type JWKCache = Arc<Mutex<HashMap<Issuer, HashMap<KeyID, Arc<RSA_JWK>>>>>;
+// Auth0 federated JWK constants
+pub const AUTH0_ISSUER_NAME: &str = "auth0";
+pub const AUTH0_REGEX_STR: &str = r"^https://[a-zA-Z0-9-]+\.us\.auth0\.com/$";
+pub const AUTH0_JWK_URL_SUFFIX: &str = ".well-known/jwks.json";
 
-/// A lazy static regex to match auth0 URLs
-static AUTH_0_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^https://[a-zA-Z0-9-]+\.us\.auth0\.com/$").unwrap());
+// Cognito federated JWK constants
+pub const COGNITO_ISSUER_NAME: &str = "cognito";
+pub const COGNITO_REGEX_STR: &str =
+    r"^https://cognito-idp\.[a-zA-Z0-9-_]+\.amazonaws\.com/[a-zA-Z0-9-_]+$";
+pub const COGNITO_JWK_URL_SUFFIX: &str = "/.well-known/jwks.json";
 
-/// A lazy static regex to match cognito URLs
-static COGNITO_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^https://cognito-idp\.[a-zA-Z0-9-_]+\.amazonaws\.com/[a-zA-Z0-9-_]+$").unwrap()
-});
+/// Creates and initializes the federated JWKs map
+fn initialize_federated_jwks() -> FederatedJWKs<FederatedJWKIssuer> {
+    let mut federated_jwks = Vec::new();
 
-/// A common interface offered by JWK issuers (this is especially useful for logging and testing)
-#[async_trait::async_trait]
-pub trait JWKIssuerInterface {
-    /// Returns the name of the issuer
-    fn issuer_name(&self) -> String;
+    // Add the Auth0 federated JWKs
+    let auth0_jwk = FederatedJWKIssuer::new(
+        AUTH0_ISSUER_NAME.into(),
+        AUTH0_JWK_URL_SUFFIX.into(),
+        AUTH0_REGEX_STR.into(),
+    );
+    federated_jwks.push(auth0_jwk);
 
-    /// Returns the JWK URL of the issuer
-    fn issuer_jwk_url(&self) -> String;
+    // Add the cognito federated JWKs
+    let cognito_jwk = FederatedJWKIssuer::new(
+        COGNITO_ISSUER_NAME.into(),
+        COGNITO_JWK_URL_SUFFIX.into(),
+        COGNITO_REGEX_STR.into(),
+    );
+    federated_jwks.push(cognito_jwk);
 
-    /// Fetches the JWKs from the issuer's JWK URL
-    async fn fetch_jwks(&self) -> Result<HashMap<KeyID, Arc<RSA_JWK>>>;
-}
-
-/// A simple JWK issuer struct
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct JWKIssuer {
-    issuer_name: String,
-    issuer_jwk_url: String,
-}
-
-impl JWKIssuer {
-    pub fn new(issuer_name: String, issuer_jwk_url: String) -> JWKIssuer {
-        JWKIssuer {
-            issuer_name,
-            issuer_jwk_url,
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl JWKIssuerInterface for JWKIssuer {
-    fn issuer_name(&self) -> String {
-        self.issuer_name.clone()
-    }
-
-    fn issuer_jwk_url(&self) -> String {
-        self.issuer_jwk_url.clone()
-    }
-
-    async fn fetch_jwks(&self) -> Result<HashMap<KeyID, Arc<RSA_JWK>>> {
-        fetch_jwks(&self.issuer_jwk_url).await
-    }
+    // Return the federated JWKs
+    FederatedJWKs::new(federated_jwks)
 }
 
 /// Fetches the JWKs from the given URL
-async fn fetch_jwks(jwk_url: &str) -> Result<HashMap<KeyID, Arc<RSA_JWK>>> {
+pub async fn fetch_jwks(jwk_url: &str) -> Result<HashMap<KeyID, Arc<RSA_JWK>>> {
     // Create the request client
     let client = utils::create_request_client();
 
@@ -123,22 +101,36 @@ pub fn get_cached_jwk_as_rsa(
 }
 
 /// Fetches the federated JWK for the given JWT
-pub async fn get_federated_jwk(jwt: &DecodedJWT) -> Result<Arc<RSA_JWK>> {
-    // Fetch the keys for the issuer
+pub async fn get_federated_jwk<T: FederatedJWKIssuerInterface + Clone>(
+    jwt: &DecodedJWT,
+    federated_jwks: FederatedJWKs<T>,
+) -> Result<Arc<RSA_JWK>> {
+    // Identify the issuer from the JWT
     let jwt_issuer = &jwt.payload.iss;
-    let keys = if AUTH_0_REGEX.is_match(jwt_issuer) {
-        let jwk_url = format!("{}.well-known/jwks.json", jwt_issuer);
-        fetch_jwks(&jwk_url).await?
-    } else if COGNITO_REGEX.is_match(jwt_issuer) {
-        let jwk_url = format!("{}/.well-known/jwks.json", jwt_issuer);
-        fetch_jwks(&jwk_url).await?
-    } else {
+
+    // Fetch the JWKs for the issuer
+    let mut found_issuer = false;
+    let mut jwks = HashMap::new();
+    for federated_issuer in federated_jwks.get_issuers() {
+        if federated_issuer.regex().is_match(jwt_issuer) {
+            // Fetch the jwks from the URL
+            let fetched_jwks = federated_issuer.fetch_jwks(jwt_issuer.into()).await?;
+
+            // Update the keys and mark the issuer as found
+            jwks = fetched_jwks;
+            found_issuer = true;
+            break;
+        }
+    }
+
+    // Ensure the issuer was found
+    if !found_issuer {
         return Err(anyhow!("Unsupported federated issuer: {}", jwt_issuer));
-    };
+    }
 
     // Fetch the key for the given key ID
     let jwt_key_id = &jwt.header.kid;
-    let key = keys
+    let key = jwks
         .get(jwt_key_id)
         .ok_or_else(|| anyhow!("Unknown kid: {}", jwt_key_id))?;
     Ok(key.clone())
@@ -180,9 +172,15 @@ fn parse_jwks(response_text: &str) -> Result<HashMap<KeyID, Arc<RSA_JWK>>> {
 }
 
 /// Starts the JWK refresh loops for the given issuers
-pub fn start_jwk_fetchers(jwk_issuers: Vec<JWKIssuer>, jwk_refresh_rate: Duration) -> JWKCache {
+pub fn start_jwk_fetchers(
+    jwk_issuers: Vec<JWKIssuer>,
+    jwk_refresh_rate: Duration,
+) -> (JWKCache, FederatedJWKs<FederatedJWKIssuer>) {
     // Create the JWK cache
     let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
+
+    // Create and initialize the federated JWKs map
+    let federated_jwks = initialize_federated_jwks();
 
     // Create the time service
     let time_service = TimeService::real();
@@ -190,7 +188,7 @@ pub fn start_jwk_fetchers(jwk_issuers: Vec<JWKIssuer>, jwk_refresh_rate: Duratio
     // Create the issuer map
     let jwk_issuer_map: HashMap<String, Arc<JWKIssuer>> = jwk_issuers
         .into_iter()
-        .map(|issuer| (issuer.issuer_name.clone(), Arc::new(issuer)))
+        .map(|issuer| (issuer.issuer_name(), Arc::new(issuer)))
         .collect();
 
     // Start the JWK refresh loops
@@ -204,7 +202,7 @@ pub fn start_jwk_fetchers(jwk_issuers: Vec<JWKIssuer>, jwk_refresh_rate: Duratio
     }
 
     // Return the JWK cache
-    jwk_cache
+    (jwk_cache, federated_jwks)
 }
 
 /// Starts a background task that periodically fetches and caches the JWKs from the given issuer

--- a/prover-service/src/external_resources/jwk_types.rs
+++ b/prover-service/src/external_resources/jwk_types.rs
@@ -1,0 +1,148 @@
+// Copyright (c) Aptos Foundation
+
+use crate::external_resources::jwk_fetcher;
+use anyhow::Result;
+use aptos_infallible::Mutex;
+use aptos_types::jwks::rsa::RSA_JWK;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+// TODO: merge this with the JWK types used by the pepper service! The code is mostly duplicated.
+
+// Useful type declarations
+pub type Issuer = String;
+pub type KeyID = String;
+pub type JWKCache = Arc<Mutex<HashMap<Issuer, HashMap<KeyID, Arc<RSA_JWK>>>>>;
+
+/// A struct representing federated JWK issuers
+#[derive(Clone)]
+pub struct FederatedJWKs<T: FederatedJWKIssuerInterface> {
+    issuers: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T: FederatedJWKIssuerInterface + Clone> FederatedJWKs<T> {
+    pub fn new(issuers: Vec<T>) -> Self {
+        FederatedJWKs {
+            issuers: Arc::new(Mutex::new(issuers)),
+        }
+    }
+
+    #[cfg(test)]
+    /// Creates an empty struct (for testing purposes)
+    pub fn new_empty() -> Self {
+        FederatedJWKs {
+            issuers: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Returns the list of federated JWK issuers
+    pub fn get_issuers(&self) -> Vec<T> {
+        self.issuers.lock().clone()
+    }
+}
+
+/// A common interface offered by Federated JWK issuers (this is useful for logging and testing)
+#[async_trait::async_trait]
+pub trait FederatedJWKIssuerInterface {
+    /// Returns the name of the issuer
+    fn issuer_name(&self) -> String;
+
+    /// Fetches the JWKs from the issuer's JWK URL
+    async fn fetch_jwks(&self, jwt_issuer: String) -> Result<HashMap<KeyID, Arc<RSA_JWK>>>;
+
+    /// Returns the regex used to identify the issuer
+    fn regex(&self) -> &Regex;
+}
+
+/// A simple Federated JWK issuer struct
+#[derive(Clone, Debug)]
+pub struct FederatedJWKIssuer {
+    issuer_name: String,
+    issuer_jwk_url_suffix: String,
+    regex: Regex,
+}
+
+impl FederatedJWKIssuer {
+    pub fn new(issuer_name: String, issuer_jwk_url_suffix: String, regex: String) -> Self {
+        // Create the regex
+        let regex = Regex::new(&regex).unwrap_or_else(|error| {
+            panic!(
+                "Failed to compile federated JWK issuer regex for {}! Error: {}",
+                issuer_name, error
+            )
+        });
+
+        // Create the struct
+        FederatedJWKIssuer {
+            issuer_name,
+            issuer_jwk_url_suffix,
+            regex,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl FederatedJWKIssuerInterface for FederatedJWKIssuer {
+    fn issuer_name(&self) -> String {
+        self.issuer_name.clone()
+    }
+
+    async fn fetch_jwks(&self, jwt_issuer: String) -> Result<HashMap<KeyID, Arc<RSA_JWK>>> {
+        let jwk_url = format!("{}{}", jwt_issuer, self.issuer_jwk_url_suffix);
+        jwk_fetcher::fetch_jwks(&jwk_url).await
+    }
+
+    fn regex(&self) -> &Regex {
+        &self.regex
+    }
+}
+
+/// A common interface offered by JWK issuers (this is useful for logging and testing)
+#[async_trait::async_trait]
+pub trait JWKIssuerInterface {
+    /// Returns the name of the issuer
+    fn issuer_name(&self) -> String;
+
+    /// Returns the JWK URL of the issuer
+    fn issuer_jwk_url(&self) -> String;
+
+    /// Fetches the JWKs from the issuer's JWK URL
+    async fn fetch_jwks(&self) -> Result<HashMap<KeyID, Arc<RSA_JWK>>>;
+}
+
+/// A simple JWK issuer struct
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct JWKIssuer {
+    issuer_name: String,
+    issuer_jwk_url: String,
+}
+
+impl JWKIssuer {
+    pub fn new(issuer_name: String, issuer_jwk_url: String) -> JWKIssuer {
+        JWKIssuer {
+            issuer_name,
+            issuer_jwk_url,
+        }
+    }
+
+    /// Returns the name of the issuer
+    pub fn issuer_name(&self) -> String {
+        self.issuer_name.clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl JWKIssuerInterface for JWKIssuer {
+    fn issuer_name(&self) -> String {
+        self.issuer_name.clone()
+    }
+
+    fn issuer_jwk_url(&self) -> String {
+        self.issuer_jwk_url.clone()
+    }
+
+    async fn fetch_jwks(&self) -> Result<HashMap<KeyID, Arc<RSA_JWK>>> {
+        jwk_fetcher::fetch_jwks(&self.issuer_jwk_url).await
+    }
+}

--- a/prover-service/src/external_resources/mod.rs
+++ b/prover-service/src/external_resources/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Aptos Foundation
 
 pub mod jwk_fetcher;
+pub mod jwk_types;
 pub mod prover_config;

--- a/prover-service/src/external_resources/prover_config.rs
+++ b/prover-service/src/external_resources/prover_config.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Aptos Foundation
 
-use crate::external_resources::jwk_fetcher::JWKIssuer;
+use crate::external_resources::jwk_types::JWKIssuer;
 use crate::utils;
 use aptos_keyless_common::input_processing::circuit_config::CircuitConfig;
 use aptos_logger::info;

--- a/prover-service/src/main.rs
+++ b/prover-service/src/main.rs
@@ -49,7 +49,7 @@ async fn main() {
     );
 
     // Start the JWK fetchers
-    let jwk_cache = jwk_fetcher::start_jwk_fetchers(
+    let (jwk_cache, federated_jwks) = jwk_fetcher::start_jwk_fetchers(
         prover_service_config.jwk_issuers.clone(),
         Duration::from_secs(prover_service_config.jwk_refresh_rate_secs),
     );
@@ -60,6 +60,7 @@ async fn main() {
         prover_service_config.clone(),
         deployment_information,
         jwk_cache,
+        federated_jwks,
     ));
 
     // Load the verification key

--- a/prover-service/src/request_handler/handler.rs
+++ b/prover-service/src/request_handler/handler.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Aptos Foundation
 
-use crate::external_resources::jwk_fetcher::JWKCache;
+use crate::external_resources::jwk_types::JWKCache;
 use crate::external_resources::prover_config::ProverServiceConfig;
 use crate::request_handler::deployment_information::DeploymentInformation;
 use crate::request_handler::prover_handler;

--- a/prover-service/src/request_handler/prover_handler.rs
+++ b/prover-service/src/request_handler/prover_handler.rs
@@ -429,6 +429,7 @@ async fn validate_prove_request_input(
         prover_service_state,
         prove_request_input,
         prover_service_state.jwk_cache(),
+        prover_service_state.federated_jwks(),
     )
     .await
     {

--- a/prover-service/src/request_handler/prover_state.rs
+++ b/prover-service/src/request_handler/prover_state.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Aptos Foundation
 
-use crate::external_resources::jwk_fetcher::JWKCache;
 use crate::external_resources::prover_config::ProverServiceConfig;
 use crate::request_handler::deployment_information::DeploymentInformation;
 use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
@@ -9,6 +8,7 @@ use rust_rapidsnark::FullProver;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use crate::external_resources::jwk_types::{FederatedJWKIssuer, FederatedJWKs, JWKCache};
 #[cfg(test)]
 use aptos_crypto::Uniform;
 
@@ -20,6 +20,7 @@ pub struct ProverServiceState {
     training_wheels_key_pair: TrainingWheelsKeyPair,
     full_prover: Arc<Mutex<Option<FullProver>>>,
     jwk_cache: JWKCache,
+    federated_jwks: FederatedJWKs<FederatedJWKIssuer>,
 }
 
 impl ProverServiceState {
@@ -28,6 +29,7 @@ impl ProverServiceState {
         prover_service_config: Arc<ProverServiceConfig>,
         deployment_information: DeploymentInformation,
         jwk_cache: JWKCache,
+        federated_jwks: FederatedJWKs<FederatedJWKIssuer>,
     ) -> Self {
         // Load the circuit configuration
         let circuit_configuration = prover_service_config.load_circuit_params();
@@ -44,6 +46,7 @@ impl ProverServiceState {
             training_wheels_key_pair,
             full_prover: Arc::new(Mutex::new(Some(full_prover))),
             jwk_cache,
+            federated_jwks,
         }
     }
 
@@ -54,6 +57,7 @@ impl ProverServiceState {
         prover_service_config: Arc<ProverServiceConfig>,
         deployment_information: DeploymentInformation,
         jwk_cache: JWKCache,
+        federated_jwks: FederatedJWKs<FederatedJWKIssuer>,
     ) -> Self {
         // Create a circuit configuration for testing
         let circuit_configuration = CircuitConfig::new();
@@ -69,6 +73,7 @@ impl ProverServiceState {
             training_wheels_key_pair,
             full_prover,
             jwk_cache,
+            federated_jwks,
         }
     }
 
@@ -85,6 +90,11 @@ impl ProverServiceState {
     /// Returns an Arc reference to the JWK cache
     pub fn jwk_cache(&self) -> JWKCache {
         self.jwk_cache.clone()
+    }
+
+    /// Returns an Arc reference to the federated JWKs
+    pub fn federated_jwks(&self) -> FederatedJWKs<FederatedJWKIssuer> {
+        self.federated_jwks.clone()
     }
 
     /// Returns an Arc reference to the full prover instance (if one exists)

--- a/prover-service/src/tests/common/mod.rs
+++ b/prover-service/src/tests/common/mod.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Aptos Foundation
 
 use self::types::{DefaultTestJWKKeyPair, TestJWKKeyPair, WithNonce};
-use crate::external_resources::jwk_fetcher::Issuer;
-use crate::external_resources::jwk_fetcher::KeyID;
+use crate::external_resources::jwk_types::{FederatedJWKs, Issuer, KeyID};
 use crate::external_resources::prover_config::ProverServiceConfig;
 use crate::request_handler::deployment_information::DeploymentInformation;
 use crate::request_handler::prover_state::{ProverServiceState, TrainingWheelsKeyPair};
@@ -114,6 +113,7 @@ pub async fn convert_prove_and_verify(
         HashMap::from_iter([("test-rsa".to_owned(), Arc::new(jwk_keypair.into_rsa_jwk()))]);
     let jwk_cache: HashMap<Issuer, HashMap<KeyID, Arc<RSA_JWK>>> =
         HashMap::from_iter([("test.oidc.provider".into(), test_jwk)]);
+    let federated_jwks = FederatedJWKs::new_empty();
 
     println!(
         "Prover service resources dir: {}",
@@ -130,6 +130,7 @@ pub async fn convert_prove_and_verify(
         prover_service_config,
         DeploymentInformation::new(),
         Arc::new(Mutex::new(jwk_cache)),
+        federated_jwks,
     );
 
     let prover_request_input = testcase.convert_to_prover_request(&jwk_keypair);

--- a/prover-service/src/tests/jwk_fetcher.rs
+++ b/prover-service/src/tests/jwk_fetcher.rs
@@ -1,12 +1,7 @@
 // Copyright (c) Aptos Foundation
 
-use crate::{
-    error::ProverServiceError,
-    external_resources::{
-        jwk_fetcher,
-        jwk_fetcher::{JWKCache, JWKIssuerInterface, KeyID},
-    },
-};
+use crate::external_resources::jwk_types::{JWKCache, JWKIssuerInterface, KeyID};
+use crate::{error::ProverServiceError, external_resources::jwk_fetcher};
 use aptos_infallible::Mutex;
 use aptos_time_service::TimeService;
 use aptos_types::{jwks, jwks::rsa::RSA_JWK};

--- a/prover-service/src/tests/request_handler.rs
+++ b/prover-service/src/tests/request_handler.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Aptos Foundation
 
-use crate::external_resources::jwk_fetcher::JWKCache;
+use crate::external_resources::jwk_types::{FederatedJWKs, JWKCache};
 use crate::external_resources::prover_config::ProverServiceConfig;
 use crate::request_handler::deployment_information::DeploymentInformation;
 use crate::request_handler::handler;
@@ -323,12 +323,16 @@ async fn send_request_to_path(
     // Get or create a JWK cache
     let jwk_cache = jwk_cache.unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())));
 
+    // Create a federated JWKs object
+    let federated_jwks = FederatedJWKs::new_empty();
+
     // Create the prover service state
     let prover_service_state = Arc::new(ProverServiceState::new_for_testing(
         training_wheels_key_pair,
         prover_service_config,
         deployment_information,
         jwk_cache,
+        federated_jwks,
     ));
 
     // Serve the request


### PR DESCRIPTION
# What is the change being pushed?
The current federated JWK tests rely on external infrastructure. This is problematic (for many reasons). To avoid these external dependencies, this PR replaces the existing federated JWK tests with those that use mocks. The benefits are: (i) our tests are now localized and reproducible (regardless of where/how they are being run); and (ii) we can modify and verify more properties.

# Testing Plan
New test infrastructure.
