### PR TITLE
[Prover Service] Add flag to disable JWT time-based checks.

### DIFF
--- a/prover-service/src/external_resources/prover_config.rs
+++ b/prover-service/src/external_resources/prover_config.rs
@@ -18,7 +18,7 @@ const MAIN_WASM_FILE_NAME: &str = "main.wasm";
 #[serde(default, deny_unknown_fields)]
 pub struct ProverServiceConfig {
     pub setup_dir: String,
-    pub resources_dir: String, // Directory with prover/verification key and witness gen binary
+    pub resources_dir: String,
     pub zkey_filename: String,
     pub verification_key_filename: String,
     pub witness_gen_binary_filename: String,
@@ -26,11 +26,9 @@ pub struct ProverServiceConfig {
     pub jwk_refresh_rate_secs: u64,
     pub port: u16,
     pub metrics_port: u16,
-    #[serde(default)]
     pub enable_test_provider: bool,
-    #[serde(default)]
     pub enable_federated_jwks: bool,
-    #[serde(default)]
+    pub disable_jwt_time_based_checks: bool,
     pub use_insecure_jwk_for_test: bool,
     pub max_committed_epk_bytes: usize,
 }
@@ -39,7 +37,7 @@ impl Default for ProverServiceConfig {
     fn default() -> Self {
         Self {
             setup_dir: "default".into(),                   // Default setup directory
-            resources_dir: "/resources/ceremonies".into(), // Default resources directory
+            resources_dir: "/resources/ceremonies".into(), // Default resources directory (with prover/verification key and witness gen binary)
             zkey_filename: "prover_key.zkey".into(),       // Default zkey filename
             verification_key_filename: "verification_key.json".into(), // Default verification key filename
             witness_gen_binary_filename: "main_c".into(), // Default witness generation binary filename
@@ -49,6 +47,7 @@ impl Default for ProverServiceConfig {
             metrics_port: 9100,                           // Run the metrics service on port 9100
             enable_test_provider: false, // Don't enable the test OIDC provider by default
             enable_federated_jwks: false, // Disable federated JWKs by default
+            disable_jwt_time_based_checks: false, // Enable JWT time-based checks by default
             use_insecure_jwk_for_test: false, // Don't use insecure JWK for testing by default
             max_committed_epk_bytes: 93, // 3 * BYTES_PACKED_PER_SCALAR (31) = 93
         }

--- a/prover-service/src/tests/training_wheels.rs
+++ b/prover-service/src/tests/training_wheels.rs
@@ -9,9 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[test]
 fn test_validate_default_jwt() {
     // Create a default JWT payload
-    let jwt_payload = TestJWTPayload {
-        ..TestJWTPayload::default()
-    };
+    let jwt_payload = TestJWTPayload::default();
 
     // Verify the JWT signature
     test_jwt_signature_validation(jwt_payload, true);
@@ -20,9 +18,7 @@ fn test_validate_default_jwt() {
 #[test]
 fn test_validate_jwt_invalid_signature() {
     // Create a default JWT payload
-    let jwt_payload = TestJWTPayload {
-        ..TestJWTPayload::default()
-    };
+    let jwt_payload = TestJWTPayload::default();
 
     // Create a test case and convert it to a prover request input
     let testcase = ProofTestCase::default_with_payload(jwt_payload).compute_nonce();

--- a/prover-service/src/tests/types.rs
+++ b/prover-service/src/tests/types.rs
@@ -247,6 +247,11 @@ impl ProofTestCase {
             skip_aud_checks: self.skip_aud_checks,
         }
     }
+
+    /// Updates the prover service config
+    pub fn update_prover_service_config(&mut self, prover_service_config: ProverServiceConfig) {
+        self.prover_service_config = prover_service_config;
+    }
 }
 
 /// Generates a test ephemeral public key


### PR DESCRIPTION
# What is the change being pushed?
This PR adds a flag to disable JWT time-based checks in the prover service. This functionality is required by CI/CD in the TS SDK repository (for testing purposes).

# Testing Plan
New and existing test infrastructure.