### PR TITLE
[Prover] Add simple metrics for JWT attributes.

### DIFF
--- a/keyless-common/src/input_processing/jwt.rs
+++ b/keyless-common/src/input_processing/jwt.rs
@@ -129,6 +129,10 @@ impl JwtParts {
         String::from(&self.payload)
     }
 
+    pub fn header_undecoded(&self) -> String {
+        String::from(&self.header)
+    }
+
     pub fn header_undecoded_with_dot(&self) -> String {
         String::from(&self.header) + "."
     }
@@ -149,6 +153,10 @@ impl JwtParts {
 
     pub fn signature(&self) -> Result<RsaSignature> {
         RsaSignature::from_b64(&self.signature)
+    }
+
+    pub fn signature_undecoded(&self) -> String {
+        String::from(&self.signature)
     }
 }
 

--- a/prover-service/src/request_handler/prover_handler.rs
+++ b/prover-service/src/request_handler/prover_handler.rs
@@ -47,7 +47,12 @@ pub async fn hande_prove_request(
     // Validate the input request
     let verified_input =
         match validate_prove_request_input(&prover_service_state, &prove_request_input).await {
-            Ok(verified_input) => verified_input,
+            Ok(verified_input) => {
+                // Update the JWT attribute metrics
+                metrics::update_jwt_attribute_metrics(&verified_input);
+
+                verified_input
+            }
             Err(error) => {
                 let error_string =
                     format!("Failed to validate prove request input! Error: {}", error);


### PR DESCRIPTION
# What is the change being pushed?
This PR adds simple metrics for tracking the sizes of JWT attributes, e.g.,. header size, payload size, iss size, etc.

# Testing Plan
Existing test infrastructure.