### PR TITLE
explicitly depend on typing_extensions

### DIFF
--- a/scripts/task.sh
+++ b/scripts/task.sh
@@ -90,8 +90,8 @@ install_deps
 if ! ls .venv &> /dev/null; then
   python3 -m venv .venv
 fi
-if ! .venv/bin/pip3 show google-cloud-storage typer &> /dev/null;  then
-  .venv/bin/pip3 install google-cloud-storage typer &> /dev/null
+if ! .venv/bin/pip3 show google-cloud-storage typer typing_extensions &> /dev/null;  then
+  .venv/bin/pip3 install google-cloud-storage typer typing_extensions &> /dev/null
 fi
 
 .venv/bin/python3 $SCRIPT_DIR/python/main.py "$@"


### PR DESCRIPTION
# What is the change being pushed?

explicitly install `typing_extensions` in task python script.

## Why are you pushing this change?

CI is broken by this.

## How is this implemented?

n/a

# Type of change

Devtool.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all keyless stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
