### PR TITLE
Docs: adopt "peppercorn" terminology (no interface changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ In a new terminal, make a request to the prover and expect it to finish normally
 ```bash
 curl -X POST -H "Content-Type: application/json" -d @/tmp/prover_request_payload.json http://localhost:8083/v0/prove
 ```
+
+## Terminology (naming update)
+
+- "the pepper": previously referred to as "pepper base"; the long-lived secret known only to the provider.
+- "peppercorn": previously referred to as "pepper"; a one-way derivative of the pepper used by the circuit and APIs.
+
+Notes:
+- Code and circuits continue to use the signal/field name `pepper` and the Rust type `aptos_types::keyless::Pepper` for backward compatibility; these represent the peppercorn.
+- External interfaces are unchanged; this section clarifies naming only.

--- a/circuit/templates/keyless.circom
+++ b/circuit/templates/keyless.circom
@@ -473,6 +473,8 @@ template keyless(
     // Compute the identity commitment (IDC)
     //
 
+    // Naming note: This is the peppercorn (one-way derivative of "the pepper").
+    // The signal remains named `pepper` for backward compatibility with tooling.
     signal input pepper;
     signal hashable_private_aud_value[MAX_AUD_VALUE_LEN];
     for (var i = 0; i < MAX_AUD_VALUE_LEN; i++) {

--- a/circuit/tools/input_gen.py
+++ b/circuit/tools/input_gen.py
@@ -591,7 +591,7 @@ print(exp_date)
 print("\nExpiration horizon:")
 print(exp_horizon)
 
-print("\nPepper")
+print("\nPeppercorn")
 print(pepper)
 
 print("\nExtra field")

--- a/prover-service/src/input_processing/public_inputs_hash.rs
+++ b/prover-service/src/input_processing/public_inputs_hash.rs
@@ -19,7 +19,7 @@ fn compute_idc_hash(
     verified_input: &VerifiedInput,
     pepper_fr: Fr,
 ) -> Result<Fr> {
-    // Add the pepper to the hash
+    // Add the peppercorn (previously called "pepper") to the hash
     let mut frs: Vec<Fr> = Vec::new();
     frs.push(pepper_fr);
 

--- a/prover-service/src/request_handler/types.rs
+++ b/prover-service/src/request_handler/types.rs
@@ -29,6 +29,8 @@ pub struct RequestInput {
     pub epk_blinder: EphemeralPublicKeyBlinder,
     pub exp_date_secs: u64,
     pub exp_horizon_secs: u64,
+    // Naming note: This field is the peppercorn (one-way derivative of "the pepper").
+    // The Rust type and JSON name remain `pepper` for backward compatibility.
     pub pepper: Pepper,
     pub uid_key: String,
     pub extra_field: Option<String>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Add a Terminology section in `README.md` clarifying the naming update:
  - "the pepper" (formerly "pepper base"): long-lived provider secret
  - "peppercorn" (formerly "pepper"): one-way derivative used by circuit/APIs
- Update comments to use "peppercorn" while retaining field/type names for compatibility:
  - `prover-service/src/input_processing/public_inputs_hash.rs` (hash comment)
  - `prover-service/src/request_handler/types.rs` (`RequestInput.pepper` doc)
  - `circuit/templates/keyless.circom` (signal `pepper` naming note)
- Update the Python tool print label to "Peppercorn" in `circuit/tools/input_gen.py`.

Notes:
- No code/ABI changes; all field names and Rust types remain `pepper` to avoid breaking dependents.
- This PR addresses the internal terminology proposal from Slack.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C06KKN0K28J/p1777936490301289?thread_ts=1777936490.301289&cid=C06KKN0K28J)

<div><a href="https://cursor.com/agents/bc-124a3443-f7df-4d74-b967-4036656ad458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-124a3443-f7df-4d74-b967-4036656ad458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

